### PR TITLE
fix: replace unused deps with groq and python-dotenv, add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.env
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+dist/
+build/
+.venv/
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask
-openai
+groq
 yfinance
 pdfplumber
-langchain
+python-dotenv


### PR DESCRIPTION
## Problem
`requirements.txt` listed `openai` and `langchain`, neither of which are used anywhere in the codebase. The app imports and uses the `groq` package throughout but it was missing entirely, causing an `ImportError` on every startup.

## Changes
- Removed unused `openai` and `langchain` dependencies
- Added `groq` (the actual LLM client used in `app.py`, `agents.py`, and `utils/multi_agent.py`)
- Added `python-dotenv` to support loading `GROQ_API_KEY` from a `.env` file
- Added `.gitignore` covering `.env` secrets, `__pycache__`, `.pyc` files, and build/venv directories

## How to test
Run `pip install -r requirements.txt` — it should complete without errors. Then `python app.py` should start Flask without any `ImportError`.