### PR TITLE
fix: load GROQ_API_KEY from .env instead of hardcoding placeholder

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,7 +1,10 @@
 from groq import Groq
+import os
+from dotenv import load_dotenv
 
-# Initialize Groq client
-client = Groq(api_key="YOUR_API_KEY")
+load_dotenv()
+
+client = Groq(api_key=os.getenv("GROQ_API_KEY"))
 
 # -----------------------
 # SIP AGENT

--- a/app.py
+++ b/app.py
@@ -2,9 +2,9 @@ from flask import Flask, request, jsonify, render_template
 import yfinance as yf
 import os
 from groq import Groq
+from dotenv import load_dotenv
 
-# ---------------- 🔐 SET API KEY ----------------
-os.environ["GROQ_API_KEY"] = "YOUR_API_KEY"
+load_dotenv()
 
 # ---------------- IMPORT UTILS ----------------
 from utils.sip import calculate_sip


### PR DESCRIPTION
## Problem
`app.py` was doing this:
```python
os.environ[GROQ_API_KEY] = YOUR_API_KEY  # literal placeholder
client = Groq(api_key=os.getenv(GROQ_API_KEY))  # reads back the placeholder
```
This caused every single Groq API call to fail with an authentication error. `agents.py` had the same bug with the key passed directly into `Groq()`.

## Changes
- Removed the hardcoded `os.environ[GROQ_API_KEY] = YOUR_API_KEY` line from `app.py`
- Added `load_dotenv()` to both `app.py` and `agents.py` so the key is read from a local `.env` file
- Both files now correctly use `os.getenv(GROQ_API_KEY)`

## How to test
Create a `.env` file in the project root with `GROQ_API_KEY=<your_real_key>`, then run `python app.py`. The `/chat` endpoint should return real AI responses instead of authentication errors.