### PR TITLE
fix: guard against ZeroDivisionError in money score and SIP calculator

### DIFF
--- a/utils/money_score.py
+++ b/utils/money_score.py
@@ -1,4 +1,8 @@
 def calculate_money_score(income, expenses, savings, investments, debt, emergency_fund):
+    if income <= 0:
+        raise ValueError("Income must be greater than zero")
+    if expenses <= 0:
+        raise ValueError("Expenses must be greater than zero")
 
     score = 0
 

--- a/utils/sip.py
+++ b/utils/sip.py
@@ -1,6 +1,9 @@
 def calculate_sip(monthly, rate, years):
-    r = rate / 100 / 12
     n = years * 12
 
-    fv = monthly * (((1 + r)**n - 1) / r) * (1 + r)
+    if rate == 0:
+        return round(monthly * n, 2)
+
+    r = rate / 100 / 12
+    fv = monthly * (((1 + r) ** n - 1) / r) * (1 + r)
     return round(fv, 2)


### PR DESCRIPTION
## Problem
Two functions crashed with `ZeroDivisionError` on valid-looking inputs:

**`utils/money_score.py`**
- `savings / income` → crashes if user enters `income = 0`
- `emergency_fund / expenses` → crashes if user enters `expenses = 0`

**`utils/sip.py`**
- `r = rate / 100 / 12` → when `rate = 0`, `r = 0`
- `(((1 + r) ** n - 1) / r)` → `0 / 0` → `ZeroDivisionError`

Both of these produce a 500 Internal Server Error with an unhandled exception traceback instead of a clean error response.

## Changes
- `money_score.py`: raises `ValueError` with a descriptive message if `income <= 0` or `expenses <= 0`. The `/money-score` route already wraps in `try/except` so this surfaces as a clean JSON error.
- `sip.py`: when `rate == 0`, returns `round(monthly * n, 2)` (the mathematically correct answer — no compounding, just the sum of contributions).