### PR TITLE
Add missing groq dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask
 openai
 yfinance
+groq
 pdfplumber
 langchain


### PR DESCRIPTION
This PR adds the missing `groq` dependency required by `app.py`.

Without this package, running the project locally raises:
`ModuleNotFoundError: No module named 'groq'`

closes #16 