### PR TITLE
Add .gitignore for Python environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+venv/
+__pycache__/
+*.pyc
+.env
+.DS_Store


### PR DESCRIPTION
Not having a .gitignore file in a python code is a hygiene issue and this PR fixes that 
closes #17