### PR TITLE
[DOCS]: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug Report
+about: Report a bug or broken behavior in LecturePulse
+title: "[Bug] "
+---
+
+## Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain the problem. -->
+
+## Environment
+
+- **Browser**: <!-- e.g. Chrome 125, Firefox 127 -->
+- **OS**: <!-- e.g. Windows 11, macOS Sonoma -->
+- **Node.js version**: <!-- e.g. 20.x -->
+
+## Affected Page / Component
+
+<!-- Which part of the app is affected? -->
+
+- [ ] Landing
+- [ ] Login
+- [ ] Dashboard
+- [ ] Student Feedback
+- [ ] Analytics
+- [ ] Other: <!-- specify -->
+
+## Additional Context
+
+<!-- Any other context about the problem. -->

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,21 @@
+---
+name: Documentation
+about: Report missing, incorrect, or outdated documentation
+title: "[Docs] "
+---
+
+## What's Missing or Incorrect
+
+<!-- Point to the specific file, section, or topic that needs attention. -->
+
+## Proposed Update
+
+<!-- Describe what should be added, corrected, or clarified. -->
+
+## Why This Matters
+
+<!-- How does this documentation gap affect contributors or users? -->
+
+## References
+
+<!-- Links to relevant code, external docs, or related issues. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for LecturePulse
+title: "[Feature] "
+---
+
+## Problem Statement
+
+<!-- What problem does this feature solve? What pain point does it address? -->
+
+## Proposed Solution
+
+<!-- Describe the feature you'd like. Be as specific as possible. -->
+
+## Alternative Approaches
+
+<!-- Have you considered any alternatives? Why is your proposed solution better? -->
+
+## Affected Area
+
+<!-- Which part of the app does this touch? -->
+
+- [ ] UI / UX
+- [ ] New component
+- [ ] New page
+- [ ] Analytics / Charts
+- [ ] Authentication
+- [ ] Other: <!-- specify -->
+
+## Mockups / Additional Context
+
+<!-- Add any mockups, screenshots, or links that help illustrate the feature. -->

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,21 @@
+---
+name: General Issue
+about: Anything that doesn't fit bug, feature, or documentation categories
+title: "e.g. [BUG] Session code input not clearing after joining"
+---
+
+## Summary
+
+<!-- A brief description of the issue. -->
+
+## Details
+
+<!-- Provide as much context as needed. -->
+
+## Why This Matters
+
+<!-- Explain the impact or motivation. -->
+
+## References / Additional Context
+
+<!-- Links to related issues, PRs, discussions, or external resources. -->

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,25 @@
+<!-- PR template for bug fixes.
+     To use: open PR with ?template=bugfix.md appended to the URL. -->
+
+## Related Issue
+Fixes #<!-- issue number -->
+
+## Root Cause
+<!-- What was causing the bug? -->
+
+## Fix Approach
+<!-- How does this PR address the root cause? -->
+
+## Pages / Components Affected
+<!-- List the files or components changed. -->
+-
+
+## Screenshots
+<!-- Include if the fix has a visible UI change. -->
+
+## Checklist
+- [ ] `npm run lint` passes with no errors
+- [ ] Tested in dev server (`npm run dev`)
+- [ ] Regression tested — existing behavior unaffected
+- [ ] No console errors or warnings
+- [ ] Screenshots attached (if UI change)

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+<!-- PR template for new features and enhancements.
+     To use: open PR with ?template=feature.md appended to the URL. -->
+
+## Related Issue
+Closes #<!-- issue number -->
+
+## Description
+<!-- Describe the feature added. What does it do and why? -->
+
+## Pages / Components Added or Modified
+<!-- List the files or components this PR touches. -->
+-
+
+## Screenshots
+<!-- Required for any UI changes. Before/after if applicable. -->
+
+## Checklist
+- [ ] `npm run lint` passes with no errors
+- [ ] Tested in dev server (`npm run dev`)
+- [ ] Responsive layout verified (mobile + desktop)
+- [ ] No console errors or warnings
+- [ ] Animations and transitions are intact (Framer Motion)
+- [ ] Screenshots attached above

--- a/.github/PULL_REQUEST_TEMPLATE/general.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general.md
@@ -1,0 +1,21 @@
+<!-- PR template for docs, refactors, chores, and everything else.
+     To use: open PR with ?template=general.md appended to the URL. -->
+
+## Related Issue
+<!-- If applicable: Closes/Fixes/Ref # -->
+
+## Type of Change
+- [ ] Documentation
+- [ ] Refactor
+- [ ] Chore / maintenance
+- [ ] Dependency update
+- [ ] Configuration / tooling
+- [ ] Other: <!-- specify -->
+
+## Summary of Changes
+<!-- What was changed and why? -->
+
+## Checklist
+- [ ] `npm run lint` passes with no errors
+- [ ] No unintended functional changes introduced
+- [ ] Tested locally (`npm run dev`)


### PR DESCRIPTION
Resolved issue #26  

## Summary
- Adds 4 issue templates: Bug Report, Feature Request, Documentation, General Issue
- Adds 3 PR templates: Feature, Bug Fix, General

## Issue Templates (`.github/ISSUE_TEMPLATE/`)
| Template | Label | Use for |
|---|---|---|
| `bug_report.md` | `bug` | Broken behavior, errors |
| `feature_request.md` | `enhancement` | New features, enhancements |
| `docs.md` | `documentation` | Missing/incorrect docs |
| `general.md` | *(none)* | Everything else |

## PR Templates (`.github/PULL_REQUEST_TEMPLATE/`)
Select the right template by appending `?template=<name>.md` to the PR URL.

| Template | Use for |
|---|---|
| `feature.md` | New features and enhancements |
| `bugfix.md` | Bug fixes |
| `general.md` | Docs, refactors, chores, dependency updates |

## Checklist
- [x] All templates include relevant checklist items (`npm run lint`, dev server, responsive, etc.)
- [x] Labels pre-assigned where applicable
- [x] PR templates include URL hint for template selection
