### PR TITLE
fix: prevent division-by-zero crashes in sip and money score calculators

### DIFF
--- a/utils/money_score.py
+++ b/utils/money_score.py
@@ -3,7 +3,7 @@ def calculate_money_score(income, expenses, savings, investments, debt, emergenc
     score = 0
 
     # 1. Savings Rate (30)
-    savings_rate = savings / income
+    savings_rate = savings / income if income > 0 else 0.0
     if savings_rate >= 0.3:
         score += 30
     elif savings_rate >= 0.2:
@@ -12,7 +12,7 @@ def calculate_money_score(income, expenses, savings, investments, debt, emergenc
         score += 10
 
     # 2. Investment Rate (25)
-    invest_rate = investments / income
+    invest_rate = investments / income if income > 0 else 0.0
     if invest_rate >= 0.2:
         score += 25
     elif invest_rate >= 0.1:
@@ -21,7 +21,7 @@ def calculate_money_score(income, expenses, savings, investments, debt, emergenc
         score += 5
 
     # 3. Debt Ratio (25)
-    debt_ratio = debt / income
+    debt_ratio = debt / income if income > 0 else (1.0 if debt > 0 else 0.0)
     if debt_ratio <= 0.2:
         score += 25
     elif debt_ratio <= 0.4:
@@ -30,7 +30,7 @@ def calculate_money_score(income, expenses, savings, investments, debt, emergenc
         score += 5
 
     # 4. Emergency Fund (20)
-    months_cover = emergency_fund / expenses
+    months_cover = emergency_fund / expenses if expenses > 0 else (12.0 if emergency_fund > 0 else 0.0)
     if months_cover >= 6:
         score += 20
     elif months_cover >= 3:

--- a/utils/sip.py
+++ b/utils/sip.py
@@ -1,6 +1,8 @@
 def calculate_sip(monthly, rate, years):
-    r = rate / 100 / 12
     n = years * 12
+    if rate == 0:
+        return round(monthly * n, 2)
 
+    r = rate / 100 / 12
     fv = monthly * (((1 + r)**n - 1) / r) * (1 + r)
     return round(fv, 2)


### PR DESCRIPTION
Closes #53 

# Summary
Prevents division-by-zero errors in the SIP and Money Score calculation utility files, preventing Flask backend 500 server crashes.

# Changes Made
- **utils/money_score.py**: Refactored calculation checks to fall back to `0.0` or standard limits if input income or expenses are zero.
- **utils/sip.py**: Added a validation check for `rate == 0` and implemented a simple sum-of-contributions return fallback.

# Testing
- **Local Testing**: Sent POST requests to `/money-score` with `"income": 0` and verified a status of `"Needs Improvement"` instead of a backend crash. Sent POST requests to `/sip` with `"rate": 0` and verified it returns the exact total money invested.
- **Code Quality**: Verified Python interpreter compilation success.

# Impact
Vastly improves the robustness and error handling of core financial computation APIs.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
