### PR TITLE
fix: disable Flask debug mode in production via FLASK_DEBUG env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Flask debug mode — set to True ONLY for local development.
+# NEVER enable in production (exposes the Werkzeug interactive debugger).
+FLASK_DEBUG=False
+
+# Your Groq API key (required for AI features)
+GROQ_API_KEY=your_api_key_here

--- a/app.py
+++ b/app.py
@@ -237,4 +237,5 @@ def delete_item():
 
 # ---------------- RUN ----------------
 if __name__ == "__main__":
-    app.run(debug=True)
+    debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ("true", "1", "yes")
+    app.run(debug=debug_mode)


### PR DESCRIPTION
## Description
Fixes the security issue — `app.py` started Flask with
`app.run(debug=True)`, which exposes the Werkzeug interactive debugger
(remote code execution risk) and leaks stack traces in production.
This app deploys to Vercel, so debug mode must be off by default.

## Changes
- `app.py`: gated debug mode behind the `FLASK_DEBUG` environment
  variable — OFF by default, opt-in only for local development:

      debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ("true", "1", "yes")
      app.run(debug=debug_mode)

- Added `.env.example` documenting `FLASK_DEBUG` (with a warning never
  to enable it in production) and `GROQ_API_KEY`.
- `os` was already imported — no new dependencies.

## Testing
- Verified `app.py` parses cleanly.
- With no env var set, debug defaults to False (production-safe).
- Setting `FLASK_DEBUG=True` locally re-enables it for development.

Closes #65