### PR TITLE
fix: remove debug print statement from production code

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ app = Flask(__name__)
 # ---------------- INIT GROQ ----------------
 client = Groq(api_key=os.getenv("GROQ_API_KEY"))
 
-print("Groq key:", client)
+
 # ---------------- HOME ----------------
 @app.route("/")
 def home():


### PR DESCRIPTION
## 📝 Related Issue
Closes #84 

## 📋 Summary
This Pull Request removes an unnecessary debug `print()` statement in `app.py` at line 27. It was logging the internal Groq client object to the console during production startup, which is unnecessary and leaks internal details in logs.


## 🛠️ Changes Made
- [x] Removed unnecessary debug statement `print("Groq key:", client)` from `app.py` (line 27).


## 🧪 Testing Verification
Detail how these changes were tested:
- **Local Testing**: Tested on a local Flask server to ensure the app starts up successfully and no longer outputs the internal Groq client object description to the console.
- **Responsiveness**: N/A (Server-side backend change)
- **Code Quality**: Syntax is clean and follows Python formatting guidelines.
## 📸 Screenshots / Demos
*N/A - This is a server-side console log fix, no UI changes were made.*

## 🌟 Impact
It ensures production server logs remain clean, professional, and free of extraneous debug outputs containing internal client object representations.

## 🏁 Checklist
- [x] Code follows project conventions and style guidelines
- [x] Tested locally and verified correctness
- [x] Contains no unrelated or extraneous formatting changes
- [ ] Mobile responsive layout verified (for frontend work)
- [ ] Accessibility standards met
- [x] Security standards followed (no hardcoded keys/secrets)
