### PR TITLE
fix: remove unused deps and pin versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-flask
-openai
-yfinance
-groq
-pdfplumber
-langchain
-python-dotenv
+flask==3.1.3
+yfinance==1.4.1
+groq==1.4.0
+pdfplumber==0.11.9
+python-dotenv==1.2.2
 pytest
 flask-sqlalchemy==3.1.1


### PR DESCRIPTION
Removes `openai` and `langchain` from requirements.txt — neither is
imported anywhere in app.py or utils/ (all LLM calls go through groq).
Pins the five real dependencies to their current stable versions for
reproducible installs across contributors.

Changes:
- Remove: openai, langchain
- Pin: flask==3.1.3, yfinance==1.4.1, groq==1.4.0,
       pdfplumber==0.11.9, python-dotenv==1.2.2

Closes #94 