### PR TITLE
feat: add persistent SQLite storage for expenses, assets, liabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,8 @@ __pycache__/
 # Pytest / coverage
 .pytest_cache/
 htmlcov/
-.coverage
+.coverage
+
+# Local database (runtime artifact)
+*.db
+instance/

--- a/app.py
+++ b/app.py
@@ -32,6 +32,16 @@ from utils.expense_track import calculate_expense, insights
 
 app = Flask(__name__)
 
+# ---------------- INIT DATABASE ----------------
+from models import db, Expense, Asset, Liability
+
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///money_mentor.db"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+db.init_app(app)
+
+with app.app_context():
+    db.create_all()
+
 # ---------------- INIT GROQ ----------------
 client = Groq(api_key=GROQ_API_KEY)
 
@@ -205,49 +215,44 @@ def money_score():
 
 # Expense Tracker Features
 
-expense_data = []
-
 @app.route("/add_expense", methods=["POST"])
 def add_expense():
     try:
         data = request.json
-
-        print("RECEIVED:", data)   # ADD THIS
-
-        expense = {
-            "category": data["category"],
-            "amount": float(data["amount"]),
-            "date": data["date"]
-        }
-
-        expense_data.append(expense)
-
-        print("ALL EXPENSES:", expense_data)   # ADD THIS
-
+        expense = Expense(
+            category=data["category"],
+            amount=float(data["amount"]),
+            date=data["date"]
+        )
+        db.session.add(expense)
+        db.session.commit()
         return jsonify({"status": "success"})
 
     except Exception as e:
-        print("ERROR:", str(e))   # ADD THIS
-        return jsonify({"error": str(e)}),400
+        return jsonify({"error": str(e)}), 400
 
 @app.route("/calculate", methods=["GET"])
 def calculate():
+    expense_data = [e.to_dict() for e in Expense.query.order_by(Expense.id).all()]
     result = calculate_expense(expense_data)
     result["expenses"] = expense_data
     return jsonify(result)
 
 @app.route("/insights", methods=["GET"])
 def expense_insights():
+    expense_data = [e.to_dict() for e in Expense.query.order_by(Expense.id).all()]
     result =insights(client,expense_data)
     return jsonify(result)
 
 # ---------------- NET WORTH TRACKER ----------------
 # Net Worth Tracker Features
-assets_data = []
-liabilities_data = []
 
 @app.route("/net-worth", methods=["GET", "POST"])
 def get_net_worth():
+    assets = Asset.query.order_by(Asset.id).all()
+    liabilities = Liability.query.order_by(Liability.id).all()
+    assets_data = [a.to_dict(i) for i, a in enumerate(assets)]
+    liabilities_data = [l.to_dict(i) for i, l in enumerate(liabilities)]
     total_assets = sum(item['amount'] for item in assets_data)
     total_liabilities = sum(item['amount'] for item in liabilities_data)
     return jsonify({
@@ -262,11 +267,9 @@ def get_net_worth():
 def add_asset():
     try:
         data = request.json
-        assets_data.append({
-            "id": len(assets_data),
-            "name": data["name"],
-            "amount": float(data["amount"])
-        })
+        asset = Asset(name=data["name"], amount=float(data["amount"]))
+        db.session.add(asset)
+        db.session.commit()
         return jsonify({"status": "success"})
     except Exception as e:
         return jsonify({"error": str(e)}), 400
@@ -275,11 +278,9 @@ def add_asset():
 def add_liability():
     try:
         data = request.json
-        liabilities_data.append({
-            "id": len(liabilities_data),
-            "name": data["name"],
-            "amount": float(data["amount"])
-        })
+        liability = Liability(name=data["name"], amount=float(data["amount"]))
+        db.session.add(liability)
+        db.session.commit()
         return jsonify({"status": "success"})
     except Exception as e:
         return jsonify({"error": str(e)}), 400
@@ -289,13 +290,16 @@ def delete_item():
     try:
         data = request.json
         item_type = data["type"] # 'asset' or 'liability'
-        item_id = int(data["id"])
+        item_id = int(data["id"]) # positional index from the frontend
 
         if item_type == 'asset':
-            assets_data.pop(item_id)
+            rows = Asset.query.order_by(Asset.id).all()
+            db.session.delete(rows[item_id])
         else:
-            liabilities_data.pop(item_id)
+            rows = Liability.query.order_by(Liability.id).all()
+            db.session.delete(rows[item_id])
 
+        db.session.commit()
         return jsonify({"status": "success"})
     except Exception as e:
         return jsonify({"error": str(e)}), 400

--- a/models.py
+++ b/models.py
@@ -1,0 +1,44 @@
+"""Database models and persistence layer for AI-Money-Mentor.
+
+Replaces the previous module-level in-memory lists (expense_data,
+assets_data, liabilities_data) with SQLite-backed storage via
+Flask-SQLAlchemy, so data survives server restarts.
+"""
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+
+
+class Expense(db.Model):
+    __tablename__ = "expenses"
+    id = db.Column(db.Integer, primary_key=True)
+    category = db.Column(db.String(120), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    date = db.Column(db.String(40), nullable=False)
+
+    def to_dict(self):
+        # Matches the original expense dict shape exactly:
+        # {"category", "amount", "date"}  (no id — frontend never used one)
+        return {"category": self.category, "amount": self.amount, "date": self.date}
+
+
+class Asset(db.Model):
+    __tablename__ = "assets"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+
+    def to_dict(self, index):
+        # Original shape: {"id", "name", "amount"} where id was the list index.
+        # Frontend deletes by list position, so we expose the positional index as id.
+        return {"id": index, "name": self.name, "amount": self.amount}
+
+
+class Liability(db.Model):
+    __tablename__ = "liabilities"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+
+    def to_dict(self, index):
+        return {"id": index, "name": self.name, "amount": self.amount}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pdfplumber
 langchain
 python-dotenv
 pytest
+flask-sqlalchemy==3.1.1


### PR DESCRIPTION
Closes #73 

## Problem
`expense_data`, `assets_data`, and `liabilities_data` were module-level
Python lists, so all data was lost on every server restart/redeploy.

## Solution
Adds a SQLite persistence layer via Flask-SQLAlchemy:

- New `models.py` with `Expense`, `Asset`, and `Liability` models
- DB initialized in `app.py` (`sqlite:///money_mentor.db`, tables auto-created on startup)
- The affected routes (`/add_expense`, `/calculate`, `/insights`,
  `/net-worth`, `/add-asset`, `/add-liability`, `/delete-item`) now read
  from and write to the database instead of in-memory lists
- `flask-sqlalchemy==3.1.1` added to requirements.txt
- Local DB file + `instance/` added to `.gitignore`

## Response shapes unchanged
Every endpoint returns the exact same JSON structure as before, so the
frontend is unaffected:
- `/calculate` → `{Total, Average, By Category, expenses}` (expenses as
  `{category, amount, date}`)
- `/net-worth` → `{assets, liabilities, total_assets, total_liabilities,
  net_worth}` with each item as `{id, name, amount}`

## delete-item compatibility
The frontend deletes net-worth items by **list position** (it passes the
array index, not a DB id). `/delete-item` preserves this exactly: it
fetches the ordered list and deletes the row at that position, matching
the original `.pop(index)` behavior.

## Testing
- `python -c "import app"` loads cleanly (tables auto-create)
- Verified via Flask test client: add/calculate expenses, add/list/delete
  assets and liabilities, error handling (400 on bad input), and data
  persistence across a simulated restart — all behave identically to the
  previous in-memory version, now with persistence.