### PR TITLE
[Feature] Add chat history / conversation context to AI Chat

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,17 +99,21 @@ def internal_server_error(error):
 
 
 # ---------------- 🤖 AI CHAT ----------------
-@app.route("/chat", methods=["POST"])
+@@app.route("/chat", methods=["POST"])
 def chat():
     try:
-        msg = request.json.get("message")
+        data = request.json
+        msg = data.get("message")
+        history = data.get("history", [])
+
+        # Build messages: system prompt + last 10 history turns + current message
+        messages = [{"role": "system", "content": "You are a financial advisor for India."}]
+        messages += history[-10:]
+        messages.append({"role": "user", "content": msg})
 
         res = client.chat.completions.create(
             model="llama-3.1-8b-instant",
-            messages=[
-                {"role": "system", "content": "You are a financial advisor for India."},
-                {"role": "user", "content": msg}
-            ]
+            messages=messages
         )
 
         return jsonify({
@@ -117,11 +121,11 @@ def chat():
         })
 
     except Exception as e:
-    	app.logger.error(f"Groq API Error: {str(e)}")
+        app.logger.error(f"Groq API Error: {str(e)}")
 
-    	return jsonify({
-        	"reply": "Unable to generate a response at the moment. Please try again later."
-    	}), 500
+        return jsonify({
+            "reply": "Unable to generate a response at the moment. Please try again later."
+        }), 500
 
 
 # ---------------- 💸 SIP ----------------

--- a/app.py
+++ b/app.py
@@ -99,7 +99,7 @@ def internal_server_error(error):
 
 
 # ---------------- 🤖 AI CHAT ----------------
-@@app.route("/chat", methods=["POST"])
+@app.route("/chat", methods=["POST"])
 def chat():
     try:
         data = request.json

--- a/templates/index.html
+++ b/templates/index.html
@@ -1651,11 +1651,13 @@ pointer;
           <input type="text" id="chatInput" placeholder="Ask anything financial…"
             onkeypress="if(event.key==='Enter') chatSend()">
           <button class="btn btn-gold" onclick="chatSend()" id="chatBtn">Send</button>
+          <button class="btn btn-ghost" onclick="clearChat()" id="clearBtn" title="Clear conversation">Clear</button>
         </div>
       </div>
     </div>
 
     <!-- ── MONEY SCORE ─────────────── -->
+
     <div id="score" class="page">
       <div class="page-title">Money <span>Score</span></div>
       <div style="display: grid; grid-template-columns: 1fr 1.2fr; gap: 20px; align-items: start; max-width: 900px;">
@@ -2257,9 +2259,12 @@ async function dashSend() {
                         dashSend();
                       }
 
-                      /* ══════════════════════════════════════════════
+                     /* ══════════════════════════════════════════════
                          FULL CHAT PAGE
                       ══════════════════════════════════════════════ */
+                      // Stores conversation history as {role, content} pairs for context
+                      const chatHistory = [];
+
                       async function chatSend() {
                         const inp = document.getElementById('chatInput');
                         const msg = inp.value.trim();
@@ -2268,8 +2273,12 @@ async function dashSend() {
                         appendMsg('chatMessages', 'user', msg);
                         setLoading('chatBtn', true);
                         try {
-                          const data = await apiFetch('/chat', { message: msg });
-                          appendMsg('chatMessages', 'bot', data.reply || data.error);
+                          const data = await apiFetch('/chat', { message: msg, history: chatHistory });
+                          const reply = data.reply || data.error;
+                          // Save both turns to history so context is passed on next message
+                          chatHistory.push({ role: 'user', content: msg });
+                          chatHistory.push({ role: 'assistant', content: reply });
+                          appendMsg('chatMessages', 'bot', reply);
                         } catch (e) {
                           appendMsg('chatMessages', 'bot', '⚠ Could not reach server.');
                         }
@@ -2279,6 +2288,26 @@ async function dashSend() {
                       function chatQuick(text) {
                         document.getElementById('chatInput').value = text;
                         chatSend();
+                      }
+
+                      function clearChat() {
+                        chatHistory.length = 0;
+                        const box = document.getElementById('chatMessages');
+                        box.innerHTML = '';
+                        const welcome = document.createElement('div');
+                        welcome.id = 'chatPageWelcome';
+                        welcome.className = 'chat-welcome';
+                        welcome.innerHTML = `
+                          <div class="chat-welcome-icon">🎯</div>
+                          <h3>Financial Guidance at Your Fingertips</h3>
+                          <p>Ask questions about investments, tax planning, portfolio strategy, SIPs, risk assessment, or any financial topic.</p>
+                          <div class="chat-features">
+                            <div class="chat-feature-item" onclick="chatQuick('How should I diversify my portfolio?')">📊 Portfolio</div>
+                            <div class="chat-feature-item" onclick="chatQuick('Best tax saving strategies for 2024-25')">💸 Tax Strategy</div>
+                            <div class="chat-feature-item" onclick="chatQuick('Should I invest in mutual funds or stocks?')">📈 Investments</div>
+                            <div class="chat-feature-item" onclick="chatQuick('How much emergency fund do I need?')">🛡️ Emergency Fund</div>
+                          </div>`;
+                        box.appendChild(welcome);
                       }
 
                       /* ══════════════════════════════════════════════


### PR DESCRIPTION
##  Related Issue
Closes #90 

## What This PR Does
The AI Chat was completely stateless , every message was sent to the Groq API
independently with no memory of previous turns. This PR adds conversation 
history so the AI remembers context within a session.

##  Changes Made

### `app.py`
- Updated `/chat` route to accept an optional `history` array from the request body
- Builds the message list as: **system prompt + last 10 history turns + current message**
- Fully backward compatible , `history` defaults to `[]` if not provided

### `templates/index.html`
- Added `chatHistory` array to store `{role, content}` pairs in the frontend
- `chatSend()` now passes `history: chatHistory` with every `/chat` request
- After each reply, both the user message and AI reply are pushed into `chatHistory`
- Added a **Clear** button next to Send to reset conversation and restore the welcome screen

## Testing Done
- Sent "My monthly income is ₹80,000" then asked "How much should I save?" — 
  AI correctly referenced the income without being told again
- Sent a 3-turn conversation , AI maintained full context across all turns  
- Clicked Clear , history wiped, welcome screen restored, AI has no memory of prior messages 
- Sent a message with no history (backward compatibility) , works fine 

##  Before / After
**Before:** Every message was independent , AI had zero memory of the conversation

**After:** AI maintains context across the full session (capped at last 10 turns 
to stay within token limits and avoid exceeding Groq API context window)

##  Files Changed
- `app.py` , `/chat` route updated
- `templates/index.html` , `chatSend()` updated, `chatHistory` array added, `clearChat()` added, Clear button added