### PR TITLE
fix: return 400 status code on error in six API routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,7 +137,7 @@ def sip():
         return jsonify({"future_value": result})
 
     except Exception as e:
-        return jsonify({"error": str(e)})
+        return jsonify({"error": str(e)}), 400
 
 
 # ---------------- 📊 STOCK ----------------
@@ -149,7 +149,7 @@ def portfolio():
         return jsonify(result)
 
     except Exception as e:
-        return jsonify({"error": str(e)})
+        return jsonify({"error": str(e)}), 400
     
 # ---------------- 💸 TAX ----------------
 @app.route("/tax", methods=["POST"])
@@ -159,7 +159,7 @@ def tax():
         return jsonify({"tax": calculate_tax(income)})
 
     except Exception as e:
-        return jsonify({"error": str(e)})
+        return jsonify({"error": str(e)}), 400
 
 
 # ---------------- 📄 PDF ----------------
@@ -171,7 +171,7 @@ def upload():
         return jsonify({"data": result})
 
     except Exception as e:
-        return jsonify({"error": str(e)})
+        return jsonify({"error": str(e)}), 400
 
 
 # ---------------- 🧠 MULTI AGENT ----------------
@@ -183,7 +183,7 @@ def run_agent_route():
         return jsonify({"response": response})
 
     except Exception as e:
-        return jsonify({"error": str(e)})
+        return jsonify({"error": str(e)}), 400
 
 
 # ---------------- 💰 MONEY SCORE ----------------
@@ -216,7 +216,7 @@ def money_score():
         })
 
     except Exception as e:
-        return jsonify({"error": str(e)})
+        return jsonify({"error": str(e)}), 400
 
 
 # Expense Tracker Features


### PR DESCRIPTION
Closes #69 

Six POST routes returned `jsonify({"error": str(e)})` with no HTTP
status code, so Flask defaulted to `200 OK` even on failure. A frontend
`if (!response.ok)` check would pass silently on these errors.

**Routes fixed:**
- `/sip`
- `/portfolio`
- `/tax`
- `/upload`
- `/agent`
- `/money-score`

Each now returns `, 400` to match the four routes that already handle
errors correctly (`/add_expense`, `/add-asset`, `/add-liability`,
`/delete-item`).

**Changes:** 6 lines in `app.py` — additions only (`, 400` appended).

Closes #69