### PR TITLE
feat: add AI-powered stock sentiment and news advisor

### DIFF
--- a/app.py
+++ b/app.py
@@ -146,6 +146,54 @@ def portfolio():
     try:
         stock = request.json["stock"].upper()
         result = get_stock_price(stock)
+        
+        # AI Sentiment Analysis
+        sentiment = "Neutral"
+        analysis = "No recent news available to analyze."
+        
+        if "error" not in result and result.get("news"):
+            headlines = [n["title"] for n in result["news"]]
+            news_text = "\n".join([f"- {h}" for h in headlines])
+            
+            prompt = (
+                f"Analyze the market sentiment for stock ticker {stock} based on the following recent news headlines:\n"
+                f"{news_text}\n\n"
+                f"Your output must be in this exact format:\n"
+                f"SENTIMENT: [Bullish / Bearish / Neutral]\n"
+                f"EXPLANATION: [A concise 2-3 sentence summary explaining why the stock is moving based on the news, or overall outlook if news is mixed.]"
+            )
+            
+            try:
+                ai_res = client.chat.completions.create(
+                    model="llama-3.1-8b-instant",
+                    messages=[
+                        {"role": "system", "content": "You are a professional stock market advisor. Be concise and accurate."},
+                        {"role": "user", "content": prompt}
+                    ]
+                )
+                ai_output = ai_res.choices[0].message.content.strip()
+                
+                # Simple parsing of the formatted output
+                if "SENTIMENT:" in ai_output:
+                    parts = ai_output.split("EXPLANATION:")
+                    sent_part = parts[0].replace("SENTIMENT:", "").strip()
+                    # Clean sentiment word
+                    for option in ["Bullish", "Bearish", "Neutral"]:
+                        if option.lower() in sent_part.lower():
+                            sentiment = option
+                            break
+                    if len(parts) > 1:
+                        analysis = parts[1].strip()
+                    else:
+                        analysis = ai_output
+                else:
+                    analysis = ai_output
+            except Exception as ai_err:
+                app.logger.error(f"Stock AI Analysis Error: {str(ai_err)}")
+                analysis = "AI Sentiment Analysis is currently unavailable."
+        
+        result["sentiment"] = sentiment
+        result["analysis"] = analysis
         return jsonify(result)
 
     except Exception as e:

--- a/templates/index.html
+++ b/templates/index.html
@@ -2510,15 +2510,48 @@ async function dashSend() {
                               cap = "N/A";
                             }
 
+                            // AI Sentiment Badge color
+                            let badgeClass = "badge-gold";
+                            if (data.sentiment === "Bullish") badgeClass = "badge-green";
+                            else if (data.sentiment === "Bearish") badgeClass = "badge-red";
+
+                            let newsHtml = "";
+                            if (data.news && data.news.length > 0) {
+                              newsHtml = `
+                                <div style="margin-top: 12px; border-top: 1px solid var(--border); padding-top: 10px;">
+                                  <span style="font-size: 10px; color: var(--muted); text-transform: uppercase; font-weight: 600;">Recent News Headlines</span>
+                                  <ul style="list-style: none; margin-top: 6px; display: flex; flex-direction: column; gap: 8px;">
+                                    ${data.news.map(n => `
+                                      <li style="font-size: 12px; line-height: 1.4; text-align: left;">
+                                        <a href="${n.link}" target="_blank" style="color: var(--teal); text-decoration: none; font-weight: 500;">${n.title}</a>
+                                        <span style="font-size: 10px; color: var(--muted); display: block; margin-top: 2px;">via ${n.publisher}</span>
+                                      </li>
+                                    `).join("")}
+                                  </ul>
+                                </div>
+                              `;
+                            }
+
                             let html = `
             <div style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em">${data.symbol} — Last Price</div>
             <div class="result-big">₹${fmtNum(data.price)}</div>
+            
+            <div style="margin-top:14px; padding: 14px; background: rgba(255,255,255,0.03); border: 1px solid var(--border); border-radius: 12px; text-align: left;">
+              <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom: 8px;">
+                <span style="font-size: 11px; color: var(--muted); text-transform: uppercase; font-weight: 600;">AI Market Outlook</span>
+                <span class="badge ${badgeClass}">${data.sentiment}</span>
+              </div>
+              <p style="font-size:13px; line-height:1.6; color: var(--text);">${data.analysis}</p>
+            </div>
+
             <div style="margin-top: 14px; display: flex; flex-direction: column; gap: 6px; font-size: 12px; border-top: 1px solid var(--border); padding-top: 10px;">
               <div style="display:flex; justify-content:space-between"><span>52W High</span><strong>₹${metrics.high_52w !== "N/A" && metrics.high_52w !== null ? fmtNum(metrics.high_52w) : "N/A"}</strong></div>
               <div style="display:flex; justify-content:space-between"><span>52W Low</span><strong>₹${metrics.low_52w !== "N/A" && metrics.low_52w !== null ? fmtNum(metrics.low_52w) : "N/A"}</strong></div>
               <div style="display:flex; justify-content:space-between"><span>Market Cap</span><strong>${cap}</strong></div>
               <div style="display:flex; justify-content:space-between"><span>P/E Ratio</span><strong>${pe}</strong></div>
             </div>
+            
+            ${newsHtml}
           `;
                             showResult('stockResult', html);
 

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -1,0 +1,65 @@
+"""
+tests/test_stock.py
+-------------------
+Unit tests for utils/stock.py — Stock price, news, and metrics extractor.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+import pandas as pd
+from utils.stock import get_stock_price
+
+
+class TestStockPrice(unittest.TestCase):
+    """Tests for the stock fetcher utility using mocked yfinance."""
+
+    @patch("utils.stock.yf.Ticker")
+    def test_get_stock_price_success(self, mock_ticker):
+        # Setup mock Ticker instance
+        mock_instance = MagicMock()
+        mock_ticker.return_value = mock_instance
+        
+        # Setup mock history DataFrame
+        dates = pd.date_range(start="2026-05-01", periods=30, freq="D")
+        mock_df = pd.DataFrame({
+            "Close": [100.0 + i for i in range(30)]
+        }, index=dates)
+        mock_instance.history.return_value = mock_df
+        
+        # Setup mock info
+        mock_instance.info = {
+            "fiftyTwoWeekHigh": 150.0,
+            "fiftyTwoWeekLow": 90.0,
+            "marketCap": 10000000,
+            "trailingPE": 25.0
+        }
+        
+        # Setup mock news
+        mock_instance.news = [
+            {"title": "News 1", "publisher": "Pub 1", "link": "http://link1"},
+            {"title": "News 2", "publisher": "Pub 2", "link": "http://link2"}
+        ]
+        
+        result = get_stock_price("AAPL")
+        
+        self.assertNotIn("error", result)
+        self.assertEqual(result["symbol"], "AAPL")
+        self.assertEqual(result["price"], 129.0)  # Last close price (100.0 + 29)
+        self.assertEqual(len(result["news"]), 2)
+        self.assertEqual(result["news"][0]["title"], "News 1")
+        self.assertEqual(result["metrics"]["high_52w"], 150.0)
+
+    @patch("utils.stock.yf.Ticker")
+    def test_get_stock_price_empty_history(self, mock_ticker):
+        # Setup mock Ticker instance returning empty history
+        mock_instance = MagicMock()
+        mock_ticker.return_value = mock_instance
+        mock_instance.history.return_value = pd.DataFrame()
+        
+        result = get_stock_price("INVALID")
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "Invalid stock symbol or no data found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/stock.py
+++ b/utils/stock.py
@@ -49,11 +49,26 @@ def get_stock_price(symbol):
         except Exception as info_err:
             print(f"Info fetch failed for {symbol}: {info_err}")
 
+        # Get latest 5 news items
+        news_items = []
+        try:
+            raw_news = stock.news
+            if raw_news:
+                for item in raw_news[:5]:
+                    news_items.append({
+                        "title": item.get("title", ""),
+                        "publisher": item.get("publisher", ""),
+                        "link": item.get("link", "")
+                    })
+        except Exception as news_err:
+            print(f"News fetch failed for {symbol}: {news_err}")
+
         return {
             "symbol": symbol,
             "price": round(price, 2),
             "history": history_data,
-            "metrics": metrics
+            "metrics": metrics,
+            "news": news_items
         }
 
     except Exception as e:


### PR DESCRIPTION
# 🚀 Pull Request Template

## 📝 Related Issue
Closes #117

## 📄 Summary
This PR enhances the stock checker tool by integrating an AI Sentiment Advisor. Previously, the stock tracker only fetched and displayed raw market prices. Now, the backend fetches the latest news headlines from Yahoo Finance and uses the Groq AI model to output a market sentiment evaluation (Bullish, Bearish, or Neutral) and a brief context-driven explanation of why the stock is moving.

## 🛠 Changes Made
- Added yfinance news scrapers in `utils/stock.py` returning structured headlines.
- Set up a prompt structure and integrated Groq Llama 3 model logic inside the `/portfolio` route in `app.py`.
- Formatted index.html to render color-coded sentiment outlook badges and news lists dynamically.
- Created `tests/test_stock.py` with mock Ticker checks and unit tests to verify parsing.

## 🧪 Testing Verification
- **Local Testing**: Wrote unit tests in `tests/test_stock.py` to assert the dictionary shapes, metrics parsing, and error-handling without triggering network hits. Checked that the Python scripts compiled cleanly.
- **Responsiveness**: Used CSS rules in index.html to ensure card contents look clean and align correctly on mobile views.
- **Code Quality**: Followed project styles, kept code changes strictly focused, and syntax compiled successfully.
