### PR TITLE
fix: resolve app redefinition at end of app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -372,13 +372,3 @@ if __name__ == "__main__":
     debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ("true", "1", "yes")
 
     app.run(debug=debug_mode)
-from flask import Flask, render_template
-
-app = Flask(__name__)
-
-@app.route("/")
-def home():
-    return render_template("index.html")
-
-    app.run(debug=debug_mode)
-


### PR DESCRIPTION
Closes #210 

# Summary
Removes the redundant Flask app redefinition from the end of `app.py` that overwrote the primary app instance.

# Changes Made
- Removed redundant lines 375-384 in `app.py` consisting of duplicate imports, application definition, and duplicate `/` route handler.

# Testing
- Executed local tests (`.venv\Scripts\pytest`) which now successfully resolve database bindings.
