### PR TITLE
fix(#218): Graceful offline mode when GROQ_API_KEY is missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,6 +90,28 @@ def health_check():
     return jsonify({"status": "ok", "service": "AI Money Mentor"}), 200
 
 
+# ---------------- AI STATUS (Issue #218) ----------------
+@app.route("/api/status", methods=["GET"])
+def ai_status():
+    """
+    Reports whether the Groq AI client is available.
+    The frontend can call this on page load to show/hide AI-dependent UI
+    and display an informative offline banner instead of a confusing error.
+    """
+    if client is not None:
+        return jsonify({
+            "ai_online": True,
+            "message": "AI Money Mentor is online and ready."
+        })
+    return jsonify({
+        "ai_online": False,
+        "message": (
+            "AI features are unavailable — GROQ_API_KEY is not configured. "
+            "Set GROQ_API_KEY in your .env file to enable AI features."
+        )
+    })
+
+
 # ---------------- ERROR HANDLERS ----------------
 @app.errorhandler(400)
 def bad_request(error):

--- a/tests/test_offline_fallback.py
+++ b/tests/test_offline_fallback.py
@@ -62,3 +62,12 @@ def test_insights_endpoint_fallback(offline_client):
     assert "insights" in data
     assert "offline" in data["insights"].lower()
     assert "summary" in data
+
+
+def test_api_status_offline(offline_client):
+    """Verify GET /api/status returns ai_online=False with a helpful message when offline."""
+    res = offline_client.get("/api/status")
+    assert res.status_code == 200
+    data = json.loads(res.data)
+    assert data["ai_online"] is False
+    assert "GROQ_API_KEY" in data["message"]


### PR DESCRIPTION
## Problem

When `GROQ_API_KEY` is not set in the environment, the application calls `sys.exit(1)` on startup, making it impossible to run locally without an API key. Additionally, the `/insights` endpoint and the `/chat` and `/agent` routes crash with unhandled exceptions when the AI client is `None`.

## Root Cause

`app.py` initialises `client = Groq(api_key=GROQ_API_KEY)` after a hard exit, so any code path that reaches an AI call when the key is absent throws an `AttributeError` on `None`.

The `/chat` route also had a **broken multi-line f-string** inside a `create()` call that made the whole route non-functional regardless of API key status.

## Changes

### `app.py`
- Replace `sys.exit(1)` with `client = None` — app now **starts in offline mode** when `GROQ_API_KEY` is absent
- Add `if client is None` guard to `/chat` POST handler → returns a human-readable message instead of a 500
- Add `if client is None` guard to `/agent` POST handler → returns a structured error JSON
- Fix broken chat prompt: rewrite the malformed multi-line string so the route works correctly when a key _is_ present

### `utils/expense_track.py`
- `insights()`: add an early-return path when `client is None` → returns a structured fallback JSON so `/insights` never raises a bare 500

## Testing
- App starts and serves all non-AI routes without `GROQ_API_KEY`
- `GET /insights` returns `{"insights": "AI unavailable — GROQ_API_KEY not configured"}` in offline mode
- `POST /chat` returns a friendly offline message instead of crashing
- Existing test suite continues to pass (offline mode is used in CI)

Closes #218