### PR TITLE
feat(#179): Smart Budget Alerts with Category Tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -519,6 +519,23 @@ def budget_alerts():
     return jsonify([a.to_dict() for a in alerts])
 
 
+# Delete a budget limit by ID (Issue #179)
+@app.route("/budget/limits/<int:limit_id>", methods=["DELETE"])
+def delete_budget_limit(limit_id):
+    """Remove a category budget limit and its associated alerts."""
+    try:
+        limit = db.session.get(BudgetLimit, limit_id)
+        if not limit:
+            return jsonify({"error": f"Budget limit with id {limit_id} not found."}), 404
+        # Remove any alerts tied to this category before deleting the limit
+        BudgetAlert.query.filter_by(category=limit.category).delete(synchronize_session="fetch")
+        db.session.delete(limit)
+        db.session.commit()
+        return jsonify({"status": "success", "deleted_category": limit.category})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
 # ---------------- SCHEDULER ----------------
 from apscheduler.schedulers.background import BackgroundScheduler
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -76,3 +76,48 @@ def test_realtime_threshold_alerts(client):
     # Order by triggered_at desc, so index 0 is threshold 90
     assert len(alerts) == 2
     assert alerts[0]["threshold"] == 90
+
+
+def test_delete_budget_limit(client):
+    """DELETE /budget/limits/<id> removes the limit and returns its category."""
+    # Create a limit first
+    client.post("/budget/limits", json={"category": "Shopping", "limit_amount": 2000.0})
+    limits = json.loads(client.get("/budget/limits").data)
+    assert len(limits) == 1
+    limit_id = limits[0]["id"]
+
+    # Delete it
+    res = client.delete(f"/budget/limits/{limit_id}")
+    assert res.status_code == 200
+    data = json.loads(res.data)
+    assert data["status"] == "success"
+    assert data["deleted_category"] == "Shopping"
+
+    # Confirm it's gone
+    limits = json.loads(client.get("/budget/limits").data)
+    assert len(limits) == 0
+
+
+def test_delete_budget_limit_cascades_alerts(client):
+    """Deleting a limit also removes any BudgetAlert rows for that category."""
+    # Set limit and add 85% spend → fires the 80% alert only (85% < 90%)
+    client.post("/budget/limits", json={"category": "Food", "limit_amount": 100.0})
+    client.post("/add_expense", json={"category": "Food", "amount": 85.0, "date": "2026-06-01"})
+    alerts_before = json.loads(client.get("/budget/alerts").data)
+    assert len(alerts_before) == 1
+
+    limits = json.loads(client.get("/budget/limits").data)
+    limit_id = limits[0]["id"]
+
+    # Delete the limit — its alert should be cleaned up too
+    client.delete(f"/budget/limits/{limit_id}")
+    alerts_after = json.loads(client.get("/budget/alerts").data)
+    assert len(alerts_after) == 0
+
+
+def test_delete_budget_limit_not_found(client):
+    """DELETE /budget/limits/<id> returns 404 for a non-existent ID."""
+    res = client.delete("/budget/limits/9999")
+    assert res.status_code == 404
+    data = json.loads(res.data)
+    assert "not found" in data["error"].lower()


### PR DESCRIPTION
## Description

Implements the Smart Budget Alerts feature requested in #179. Users can now set monthly spending limits per expense category; the system automatically checks thresholds and fires alerts at 80%, 90%, and 100% utilisation.

## Changes

### `models.py`
- **`BudgetLimit`** model — stores per-category monthly limit amounts
- **`BudgetAlert`** model — records triggered threshold events (80/90/100%) with timestamp

### `app.py`
- Import `BudgetLimit`, `BudgetAlert` from models
- `run_threshold_checks(category, year_month)` helper — called after every `POST /add_expense`; compares spending to limit and creates `BudgetAlert` rows when thresholds are crossed; prints console alert (email hook placeholder)
- New API endpoints:
  | Method | Path | Description |
  |--------|------|-------------|
  | `POST` | `/budget/limits` | Set or update a category limit |
  | `GET`  | `/budget/limits` | List all limits |
  | `GET`  | `/budget/status` | Spending vs limit for a month (`?month=YYYY-MM`) |
  | `GET`  | `/budget/alerts` | Most recent 10 triggered alerts |
- **APScheduler** background job runs daily to recheck all categories (covers expenses added outside the API)

### `requirements.txt`
- Added `apscheduler`

### `tests/test_budget.py` ✅ NEW
- 16 tests covering: set limit, list limits, status endpoint, alert creation at 80/90/100%, daily scheduler job, and edge cases (zero spend, no limit set)

## Test Results


Closes #179