### PR TITLE
fix(#196): Refactor monolithic index.html into modular templates — fix inaccessible dashboard sections

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,6 +102,9 @@ def bad_request(error):
 
 @app.errorhandler(404)
 def not_found(error):
+    # Return HTML page for browser navigation, JSON for API clients
+    if request.accept_mimetypes.accept_html and not request.accept_mimetypes.accept_json:
+        return render_template("404.html", active_page=None), 404
     return jsonify({
         "error": "Not Found",
         "message": "The requested endpoint does not exist.",

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+
+{% block title %}404 — Page Not Found | AI Money Mentor{% endblock %}
+
+{% block content %}
+<div class="error-page">
+    <div class="error-card">
+        <div class="error-code">404</div>
+        <div class="error-icon">🔍</div>
+        <h1 class="error-title">Page Not Found</h1>
+        <p class="error-message">
+            The page you're looking for doesn't exist or has been moved.
+        </p>
+        <div class="error-actions">
+            <a href="{{ url_for('home') }}" class="btn-primary">
+                🏠 Back to Dashboard
+            </a>
+        </div>
+    </div>
+</div>
+
+<style>
+.error-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 70vh;
+    padding: 2rem;
+}
+
+.error-card {
+    background: var(--card-bg, #1e1e2e);
+    border: 1px solid var(--border, rgba(255,255,255,0.08));
+    border-radius: 1.5rem;
+    padding: 3rem 4rem;
+    text-align: center;
+    max-width: 480px;
+    width: 100%;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+}
+
+.error-code {
+    font-size: 6rem;
+    font-weight: 800;
+    line-height: 1;
+    background: linear-gradient(135deg, #6c63ff, #48cfad);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 0.5rem;
+}
+
+.error-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.error-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-primary, #f8f8f8);
+    margin: 0 0 0.75rem;
+}
+
+.error-message {
+    color: var(--text-secondary, #a0a0b0);
+    font-size: 1rem;
+    margin-bottom: 2rem;
+    line-height: 1.6;
+}
+
+.btn-primary {
+    display: inline-block;
+    padding: 0.75rem 2rem;
+    background: linear-gradient(135deg, #6c63ff, #48cfad);
+    color: #fff;
+    border-radius: 0.75rem;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.95rem;
+    transition: opacity 0.2s, transform 0.2s;
+}
+
+.btn-primary:hover {
+    opacity: 0.9;
+    transform: translateY(-2px);
+}
+</style>
+{% endblock %}


### PR DESCRIPTION
## Problem

All UI sections were crammed into a single `templates/index.html` (~1500 lines). Navigation used JavaScript show/hide, so most sidebar links were either non-functional or unreachable. Users could only access the main dashboard; every other section failed silently.

## Root Cause

- A single SPA-style HTML file with `display:none` toggling is fragile and breaks when JS fails or routes are navigated to directly
- No server-side routes existed for sections like /expense, /networth, /stock, /chat etc.
- The `app.py` `/chat`, `/sip`, `/tax`, `/money-score` routes only accepted `POST`, so navigating to them in a browser returned 405

## Solution

### Templates — replace monolithic file with modular structure

| File | Action |
|------|--------|
| `templates/index.html` | ❌ Deleted |
| `templates/base.html` | ✅ New — shared layout, sidebar with `active_page` highlighting |
| `templates/dashboard.html` | ✅ New |
| `templates/chat.html` | ✅ New |
| `templates/score.html` | ✅ New |
| `templates/sip.html` | ✅ New |
| `templates/stock.html` | ✅ New |
| `templates/tax.html` | ✅ New |
| `templates/pdf.html` | ✅ New |
| `templates/agent.html` | ✅ New |
| `templates/expense.html` | ✅ New |
| `templates/networth.html` | ✅ New |
| `templates/budget.html` | ✅ New |
| `static/styles/main.css` | ✅ New — CSS extracted from index.html |

### `app.py` — register server-side routes for every section

- `GET /` now renders `dashboard.html` (with `active_page="dashboard"`)
- New page routes: `GET /stock`, `GET /pdf-parser`, `GET /agent-page`, `GET /expense`, `GET /networth`, `GET /budget`
- `/chat`, `/sip`, `/tax`, `/money-score` now accept both `GET` (renders template) and `POST` (returns JSON)
- All sidebar links use Flask `url_for()` — every section is reachable via direct URL

### `utils/stock.py`
- Add missing `news` field to API response (was causing a KeyError in the template)

## Result

Every dashboard section is now accessible via its own URL. Navigating directly to `/expense`, `/chat`, `/stock` etc. renders the correct page with the correct sidebar item highlighted.

Closes #196