### PR TITLE
[ELUSOC] fix: app.py contains duplicated/corrupted Flask app initialization 

### DIFF
--- a/app.py
+++ b/app.py
@@ -370,15 +370,6 @@ def delete_item():
 # ---------------- RUN ----------------
 if __name__ == "__main__":
     debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ("true", "1", "yes")
-
     app.run(debug=debug_mode)
-from flask import Flask, render_template
 
-app = Flask(__name__)
-
-@app.route("/")
-def home():
-    return render_template("index.html")
-
-    app.run(debug=debug_mode)
 


### PR DESCRIPTION
Fixed app.py by removing the corrupted duplicated Flask initialization at the bottom of the file (the second app = Flask(__name__), the duplicated / route, and the misplaced app.run(...) that was inside the route block). app.run(debug=debug_mode) now appears only once under the correct if __name__ == "__main__": guard.




closes #216