### PR TITLE
fix: use stable database IDs for net worth item deletion

### DIFF
--- a/app.py
+++ b/app.py
@@ -354,10 +354,13 @@ def expense_insights():
 def get_net_worth():
     assets = Asset.query.order_by(Asset.id).all()
     liabilities = Liability.query.order_by(Liability.id).all()
-    assets_data = [a.to_dict(i) for i, a in enumerate(assets)]
-    liabilities_data = [l.to_dict(i) for i, l in enumerate(liabilities)]
+
+    assets_data = [a.to_dict() for a in assets]
+    liabilities_data = [l.to_dict() for l in liabilities]
+
     total_assets = sum(item['amount'] for item in assets_data)
     total_liabilities = sum(item['amount'] for item in liabilities_data)
+
     return jsonify({
         "assets": assets_data,
         "liabilities": liabilities_data,
@@ -392,18 +395,24 @@ def add_liability():
 def delete_item():
     try:
         data = request.json
-        item_type = data["type"] # 'asset' or 'liability'
-        item_id = int(data["id"]) # positional index from the frontend
+        item_type = data["type"]
+        item_id = int(data["id"])
 
-        if item_type == 'asset':
-            rows = Asset.query.order_by(Asset.id).all()
-            db.session.delete(rows[item_id])
+        if item_type == "asset":
+            item = Asset.query.get(item_id)
+        elif item_type == "liability":
+            item = Liability.query.get(item_id)
         else:
-            rows = Liability.query.order_by(Liability.id).all()
-            db.session.delete(rows[item_id])
+            return jsonify({"error": "Invalid item type"}), 400
 
+        if item is None:
+            return jsonify({"error": "Item not found"}), 404
+
+        db.session.delete(item)
         db.session.commit()
+
         return jsonify({"status": "success"})
+
     except Exception as e:
         return jsonify({"error": str(e)}), 400
 

--- a/models.py
+++ b/models.py
@@ -100,8 +100,12 @@ class Asset(db.Model):
     name = db.Column(db.String(120), nullable=False)
     amount = db.Column(db.Float, nullable=False)
 
-    def to_dict(self, index):
-        return {"id": index, "name": self.name, "amount": self.amount}
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "amount": self.amount
+        }
 
 
 class Liability(db.Model):
@@ -110,8 +114,12 @@ class Liability(db.Model):
     name = db.Column(db.String(120), nullable=False)
     amount = db.Column(db.Float, nullable=False)
 
-    def to_dict(self, index):
-        return {"id": index, "name": self.name, "amount": self.amount}
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "amount": self.amount
+        }
 
 
 class BudgetLimit(db.Model):

--- a/templates/networth.html
+++ b/templates/networth.html
@@ -81,12 +81,12 @@
       if (data.assets.length === 0) {
         assetList.innerHTML = '<tr><td colspan="3" style="text-align: center; padding: 20px; color: var(--muted); font-style: italic;">No assets added yet</td></tr>';
       } else {
-        data.assets.forEach((item, idx) => {
+        data.assets.forEach((item) => {
           assetList.innerHTML += `
             <tr style="border-bottom: 1px solid var(--border);">
               <td style="padding: 8px;">${item.name}</td>
               <td style="padding: 8px; text-align: right;">₹${fmtNum(item.amount)}</td>
-              <td style="padding: 8px; text-align: center;"><button class="btn btn-ghost" style="padding: 4px 8px; font-size: 10px;" onclick="deleteNWItem('asset', ${idx})">✖</button></td>
+              <td style="padding: 8px; text-align: center;"><button class="btn btn-ghost" style="padding: 4px 8px; font-size: 10px;" onclick="deleteNWItem('asset', ${item.id})">✖</button></td>
             </tr>
           `;
         });
@@ -97,12 +97,12 @@
       if (data.liabilities.length === 0) {
         liabList.innerHTML = '<tr><td colspan="3" style="text-align: center; padding: 20px; color: var(--muted); font-style: italic;">No liabilities added yet</td></tr>';
       } else {
-        data.liabilities.forEach((item, idx) => {
+        data.liabilities.forEach((item) => { 
           liabList.innerHTML += `
             <tr style="border-bottom: 1px solid var(--border);">
               <td style="padding: 8px;">${item.name}</td>
               <td style="padding: 8px; text-align: right;">₹${fmtNum(item.amount)}</td>
-              <td style="padding: 8px; text-align: center;"><button class="btn btn-ghost" style="padding: 4px 8px; font-size: 10px;" onclick="deleteNWItem('liability', ${idx})">✖</button></td>
+              <td style="padding: 8px; text-align: center;"><button class="btn btn-ghost" style="padding: 4px 8px; font-size: 10px;" onclick="deleteNWItem('liability', ${item.id})">✖</button></td>
             </tr>
           `;
         });
@@ -127,9 +127,12 @@
     } catch (e) { alert('Could not save. Is Flask running?'); }
   }
 
-  async function deleteNWItem(type, idx) {
+  async function deleteNWItem(type, itemId) {
     try {
-      await apiFetch('/delete-item', { type, id: idx });
+        await apiFetch('/delete-item', {
+            type,
+            id: itemId
+        });
       loadNetWorth();
     } catch (e) { alert('Could not delete. Is Flask running?'); }
   }


### PR DESCRIPTION
## Description

This PR fixes the issue where net worth items were being deleted using positional array indexes instead of stable database IDs.

### Problem

The `/delete-item` endpoint relied on frontend-provided positional indexes and deleted records using list positions. This could lead to incorrect deletions when records were reordered, removed, or when frontend and backend state became inconsistent.

### Changes Made

#### Backend

* Updated `Asset.to_dict()` to return the actual database ID (`self.id`) instead of an array index.
* Updated `Liability.to_dict()` to return the actual database ID (`self.id`) instead of an array index.
* Refactored the `/delete-item` endpoint to query and delete records using database IDs.
* Added validation for invalid item types and missing records.

#### Frontend

* Updated asset deletion buttons to send database IDs instead of array indexes.
* Updated liability deletion buttons to send database IDs instead of array indexes.
* Updated delete handler to work with stable record IDs.

### Testing

* Added multiple assets and liabilities.
* Verified `/net-worth` returns database IDs.
* Tested deletion of assets and liabilities from the UI.
* Confirmed that the correct records are removed after refresh.
* Verified application runs successfully after changes.

### Result

Net worth items are now deleted using stable database primary keys, ensuring correct and predictable deletion behavior.
