### PR TITLE
feat: Add Goal-Based Savings Planner (Reverse SIP Calculator)

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ if not GROQ_API_KEY or GROQ_API_KEY.strip() in ("", "your_groq_api_key_here"):
 else:
     client = Groq(api_key=GROQ_API_KEY)
 # ---------------- IMPORT UTILS ----------------
-from utils.sip import calculate_sip
+from utils.sip import calculate_sip, calculate_goal_sip
 from utils.tax import calculate_tax
 from utils.pdf_parser import extract_income
 from utils.money_score import calculate_money_score
@@ -240,6 +240,28 @@ def sip():
             "inflation_adjusted_value": result["inflation_adjusted_value"],
             "inflation_applied": result["inflation_applied"]
         })
+
+    except ValidationError as e:
+        raise e
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+# ---------------- 🎯 GOAL-BASED SAVINGS PLANNER ----------------
+@app.route("/goal-planner", methods=["GET", "POST"])
+def goal_planner():
+    if request.method == "GET":
+        return render_template("goal_planner.html", active_page="goal_planner")
+    try:
+        data = request.json or {}
+        if not isinstance(data, dict):
+            raise ValidationError("Request body must be a JSON object")
+        goal = validate_float(data.get("goal"), "goal", min_val=0.01)
+        rate = validate_float(data.get("rate"), "rate", min_val=0.0)
+        years = validate_int(data.get("years"), "years", min_val=1)
+
+        result = calculate_goal_sip(goal, rate, years)
+        return jsonify(result)
 
     except ValidationError as e:
         raise e

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,6 +30,7 @@
     <a href="/chat" class="nav-item {% if active_page == 'chat' %}active{% endif %}"><span class="icon">🤖</span> AI Chat</a>
     <a href="/money-score" class="nav-item {% if active_page == 'score' %}active{% endif %}"><span class="icon">💰</span> Money Score</a>
     <a href="/sip" class="nav-item {% if active_page == 'sip' %}active{% endif %}"><span class="icon">📈</span> SIP Calc</a>
+    <a href="/goal-planner" class="nav-item {% if active_page == 'goal_planner' %}active{% endif %}"><span class="icon">🎯</span> Goal Planner</a>
     <a href="/stock" class="nav-item {% if active_page == 'stock' %}active{% endif %}"><span class="icon">📊</span> Stock Check</a>
     <a href="/tax" class="nav-item {% if active_page == 'tax' %}active{% endif %}"><span class="icon">💸</span> Tax Planner</a>
     <a href="/pdf-parser" class="nav-item {% if active_page == 'pdf' %}active{% endif %}"><span class="icon">📄</span> PDF Parser</a>

--- a/templates/goal_planner.html
+++ b/templates/goal_planner.html
@@ -1,0 +1,121 @@
+{% extends 'base.html' %}
+
+{% block title %}Goal Planner{% endblock %}
+
+{% block content %}
+<div id="goal_planner" class="page active">
+  <div class="page-title">🎯 Goal-Based <span>Savings Planner</span></div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1.2fr; gap: 20px; align-items: start; max-width: 900px;">
+    <div class="card">
+      <div class="card-title">Reverse SIP Calculator</div>
+
+      <label>Goal Name</label>
+      <input type="text" id="goal_name" placeholder="e.g. Dream Home, Car, Vacation">
+
+      <label>Goal Amount (₹)</label>
+      <input type="number" required min="0" id="goal_amount" placeholder="e.g. 1000000">
+
+      <label>Time to Achieve Goal (Years)</label>
+      <input type="number" required min="1" id="goal_years" placeholder="e.g. 3">
+
+      <label>Expected Annual Return (%)</label>
+      <input type="number" required min="0" id="goal_rate" placeholder="e.g. 12">
+
+      <div style="display:flex;gap:10px;margin-top:16px;">
+        <button class="btn btn-gold" style="flex:1" onclick="calcGoalPlanner()" id="goalBtn">Calculate</button>
+        <button class="btn btn-ghost" style="flex:1" onclick="resetGoalPlanner()" id="goalResetBtn">Reset</button>
+      </div>
+
+      <div id="goalResult" class="result-box"></div>
+    </div>
+
+    <div class="card" style="min-height: 380px;">
+      <div class="card-title">Investment Breakdown</div>
+      <div style="position: relative; height: 320px;">
+        <canvas id="goalChart"></canvas>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  let goalChartInstance = null;
+
+  async function calcGoalPlanner() {
+    const name = document.getElementById('goal_name').value.trim();
+    const goal = document.getElementById('goal_amount').value;
+    const years = document.getElementById('goal_years').value;
+    const rate = document.getElementById('goal_rate').value;
+
+    if (!goal || !years || !rate) {
+      showResult('goalResult', '⚠ Please fill all fields.');
+      return;
+    }
+
+    setLoading('goalBtn', true);
+    try {
+      const data = await apiFetch('/goal-planner', {
+        goal: parseFloat(goal),
+        years: parseInt(years),
+        rate: parseFloat(rate)
+      });
+
+      if (data.error) {
+        showResult('goalResult', `⚠ ${data.error}`);
+      } else {
+        const title = name ? `Plan for "${name}"` : 'Your Plan';
+        showResult('goalResult', `
+          <div style="font-size:11px;color:var(--muted);margin-bottom:6px;text-transform:uppercase;letter-spacing:0.06em">${title} — Monthly SIP Required</div>
+          <div class="result-big">₹${fmtNum(data.monthly_sip)}</div>
+          <div style="font-size:12px;color:var(--muted);margin-top:6px">
+            Total Invested: ₹${fmtNum(data.total_invested)} &nbsp;·&nbsp;
+            Wealth Gained: ₹${fmtNum(data.returns)}
+          </div>
+        `);
+
+        if (goalChartInstance) goalChartInstance.destroy();
+        const ctx = document.getElementById('goalChart').getContext('2d');
+        goalChartInstance = new Chart(ctx, {
+          type: 'doughnut',
+          data: {
+            labels: ['Total Invested', 'Wealth Gained (Returns)'],
+            datasets: [{
+              data: [data.total_invested, Math.max(data.returns, 0)],
+              backgroundColor: ['#5a6a82', '#2ecc8a'],
+              borderWidth: 0
+            }]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { labels: { color: '#eef0f5', font: { family: 'Instrument Sans' } } }
+            },
+            cutout: '70%'
+          }
+        });
+      }
+    } catch (e) {
+      showResult('goalResult', '⚠ Could not reach server.');
+    }
+    setLoading('goalBtn', false);
+  }
+
+  function resetGoalPlanner() {
+    document.getElementById('goal_name').value = '';
+    document.getElementById('goal_amount').value = '';
+    document.getElementById('goal_years').value = '';
+    document.getElementById('goal_rate').value = '';
+    const res = document.getElementById('goalResult');
+    res.innerHTML = '';
+    res.classList.remove('visible');
+    if (goalChartInstance) {
+      goalChartInstance.destroy();
+      goalChartInstance = null;
+    }
+  }
+</script>
+{% endblock %}

--- a/tests/test_goal_planner.py
+++ b/tests/test_goal_planner.py
@@ -1,0 +1,57 @@
+"""
+tests/test_goal_planner.py
+---------------------------
+Unit tests for utils/sip.py — Goal-Based Savings Planner (reverse SIP).
+
+All tests are pure-math: no network calls, no LLM, no env variables.
+Run with:  pytest tests/test_goal_planner.py -v
+"""
+
+import pytest
+from utils.sip import calculate_goal_sip, calculate_sip
+
+
+class TestCalculateGoalSip:
+    """Tests for the reverse-SIP (goal -> required monthly investment) formula."""
+
+    def test_zero_rate_splits_goal_evenly(self):
+        """At 0% annual rate, monthly SIP is simply goal / months."""
+        result = calculate_goal_sip(goal=120000, rate=0, years=1)
+        assert result["monthly_sip"] == 10000.0
+        assert result["total_invested"] == 120000.0
+        assert result["returns"] == 0.0
+
+    def test_positive_rate_requires_less_than_zero_rate(self):
+        """A positive return rate should require a smaller monthly SIP than 0%."""
+        zero_rate = calculate_goal_sip(goal=1000000, rate=0, years=5)
+        positive_rate = calculate_goal_sip(goal=1000000, rate=12, years=5)
+        assert positive_rate["monthly_sip"] < zero_rate["monthly_sip"]
+
+    def test_returns_dict_type(self):
+        result = calculate_goal_sip(goal=500000, rate=10, years=3)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"monthly_sip", "total_invested", "returns"}
+
+    def test_total_invested_plus_returns_equals_goal(self):
+        result = calculate_goal_sip(goal=1000000, rate=12, years=3)
+        assert abs((result["total_invested"] + result["returns"]) - 1000000) < 0.01
+
+    def test_round_trip_with_calculate_sip(self):
+        """Feeding the resulting monthly SIP back into calculate_sip should
+        reproduce (approximately) the original goal amount."""
+        goal = 1000000
+        rate = 12
+        years = 3
+        result = calculate_goal_sip(goal=goal, rate=rate, years=years)
+
+        fv = calculate_sip(monthly=result["monthly_sip"], rate=rate, years=years)
+        assert abs(fv["nominal_value"] - goal) < 1.0
+
+    @pytest.mark.parametrize("goal,rate,years", [
+        (1000000, 12, 3),
+        (500000, 8, 5),
+        (5000000, 15, 20),
+    ])
+    def test_monthly_sip_always_positive(self, goal, rate, years):
+        result = calculate_goal_sip(goal, rate, years)
+        assert result["monthly_sip"] > 0

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -172,6 +172,53 @@ class TestEndpointValidation(unittest.TestCase):
         })
         self.assertEqual(response.status_code, 400)
 
+    def test_goal_planner_endpoint(self):
+        # Valid payload
+        response = self.app.post('/goal-planner', json={
+            "goal": 1000000,
+            "rate": 12,
+            "years": 3
+        })
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertIn("monthly_sip", data)
+        self.assertIn("total_invested", data)
+        self.assertIn("returns", data)
+
+        # Zero rate should fall back to a simple division
+        response = self.app.post('/goal-planner', json={
+            "goal": 120000,
+            "rate": 0,
+            "years": 1
+        })
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data["monthly_sip"], 10000.0)
+
+        # Missing goal
+        response = self.app.post('/goal-planner', json={
+            "rate": 12,
+            "years": 3
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("goal", response.get_json()["message"])
+
+        # Zero/negative goal
+        response = self.app.post('/goal-planner', json={
+            "goal": 0,
+            "rate": 12,
+            "years": 3
+        })
+        self.assertEqual(response.status_code, 400)
+
+        # Zero/negative years
+        response = self.app.post('/goal-planner', json={
+            "goal": 1000000,
+            "rate": 12,
+            "years": 0
+        })
+        self.assertEqual(response.status_code, 400)
+
     def test_tax_endpoint(self):
         # Valid payload
         response = self.app.post('/tax', json={

--- a/utils/sip.py
+++ b/utils/sip.py
@@ -1,3 +1,26 @@
+def calculate_goal_sip(goal, rate, years):
+    """Reverse SIP: given a target corpus, work out the required monthly SIP.
+
+    Uses the future-value-of-annuity-due formula (SIP at the start of each
+    month), solved for the monthly contribution.
+    """
+    n = years * 12
+    if rate == 0:
+        monthly = goal / n
+    else:
+        r = rate / 100 / 12
+        monthly = goal * r / (((1 + r) ** n - 1) * (1 + r))
+
+    total_invested = monthly * n
+    returns = goal - total_invested
+
+    return {
+        "monthly_sip": round(monthly, 2),
+        "total_invested": round(total_invested, 2),
+        "returns": round(returns, 2)
+    }
+
+
 def calculate_sip(monthly, rate, years, inflation_rate=0.0):
     n = years * 12
     if rate == 0:


### PR DESCRIPTION
## Summary
- Adds a `/goal-planner` page (Reverse SIP Calculator) where users enter a goal name, target amount, time horizon, and expected annual return, and get the required monthly SIP, total invested, and wealth gained.
- Adds `calculate_goal_sip()` to `utils/sip.py` using the future-value-of-annuity-due formula, with a 0%-rate fallback (`goal / months`).
- Adds the "Goal Planner" nav link, consistent with the existing SIP Calculator page styling/layout.

## Test plan
- [x] Added unit tests for `calculate_goal_sip` (`tests/test_goal_planner.py`)
- [x] Added `/goal-planner` endpoint validation tests (`tests/test_validation.py`) covering valid input, 0% rate, missing/zero/negative goal, and zero years
- [x] `pytest` passes for all related test files
- [x] Manually ran the app and exercised `/goal-planner` in a browser - form submission, result values, and chart render correctly with no console errors

Fixes #254
