### PR TITLE
“Tax scenario simulator” (compare regimes + deductions sensitivity)

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,19 @@ from utils.validation import ValidationError, validate_string, validate_float, v
 app = Flask(__name__)
 
 # ---------------- INIT DATABASE ----------------
-from models import db, Expense, Asset, Liability, BudgetLimit, BudgetAlert, PriceAlert, FinancialGoal
+from models import (
+    db,
+    Expense,
+    Asset,
+    Liability,
+    BudgetLimit,
+    BudgetAlert,
+    PriceAlert,
+    FinancialGoal,
+    FinancialGoalMilestone,
+)
+
+
 
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///money_mentor.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
@@ -710,6 +722,85 @@ def delete_budget_limit(limit_id):
 
 
 # ---------------- FINANCIAL GOALS TRACKER ----------------
+def _months_diff(start_dt, end_dt):
+    return (end_dt.year - start_dt.year) * 12 + (end_dt.month - start_dt.month)
+
+
+def _ym_add_months(base_dt, months):
+    # base_dt is a datetime; normalize to first day
+    year = base_dt.year + (base_dt.month - 1 + months) // 12
+    month = (base_dt.month - 1 + months) % 12 + 1
+    return year, month
+
+
+def compute_monthly_milestones(goal):
+    """Compute milestones as an even split across months until goal.target_date.
+
+    Returns list of dicts: [{month, target_amount_for_month, status}]
+    """
+    from datetime import datetime
+
+    remaining = float(goal.target_amount) - float(goal.current_amount)
+    # If already reached/exceeded, all milestones become 0 and marked completed.
+    if remaining <= 0:
+        target_dt = datetime.strptime(goal.target_date, "%Y-%m")
+        now = datetime.now()
+        months_remaining = _months_diff(datetime(now.year, now.month, 1), datetime(target_dt.year, target_dt.month, 1))
+        if months_remaining < 0:
+            months_remaining = 0
+        if months_remaining == 0:
+            months_remaining = 1
+
+        milestones = []
+        for i in range(months_remaining):
+            y, m = _ym_add_months(datetime(now.year, now.month, 1), i)
+            milestones.append({
+                "month": f"{y:04d}-{m:02d}",
+                "target_amount_for_month": 0.0,
+                "status": "completed",
+            })
+        return milestones
+
+    target_dt = datetime.strptime(goal.target_date, "%Y-%m")
+    now = datetime.now()
+
+    start = datetime(now.year, now.month, 1)
+    end = datetime(target_dt.year, target_dt.month, 1)
+    months_remaining = _months_diff(start, end)
+    if months_remaining <= 0:
+        months_remaining = 1
+
+    # Even split with rounding correction on the last month.
+    base = remaining / months_remaining
+    amounts = [round(base, 2) for _ in range(months_remaining)]
+    total_alloc = round(sum(amounts), 2)
+    diff = round(remaining - total_alloc, 2)
+    amounts[-1] = round(amounts[-1] + diff, 2)
+
+    milestones = []
+    for i in range(months_remaining):
+        y, m = _ym_add_months(start, i)
+        milestones.append({
+            "month": f"{y:04d}-{m:02d}",
+            "target_amount_for_month": float(amounts[i]),
+            "status": "planned",
+        })
+
+    return milestones
+
+
+def persist_goal_milestones(goal, milestones):
+    FinancialGoalMilestone.query.filter_by(goal_id=goal.id).delete(synchronize_session=False)
+    for ms in milestones:
+        db.session.add(FinancialGoalMilestone(
+            goal_id=goal.id,
+            month=ms["month"],
+            target_amount_for_month=ms["target_amount_for_month"],
+            status=ms["status"],
+        ))
+    db.session.commit()
+
+
 @app.route("/goals", methods=["GET", "POST"])
 def goals():
     if request.method == "GET":
@@ -731,11 +822,16 @@ def goals():
         )
         db.session.add(goal)
         db.session.commit()
+
+        milestones = compute_monthly_milestones(goal)
+        persist_goal_milestones(goal, milestones)
+
         return jsonify({"status": "success", "goal": goal.to_dict()})
     except ValidationError as e:
         raise e
     except Exception as e:
         return jsonify({"error": str(e)}), 400
+
 
 
 @app.route("/goals/<int:goal_id>", methods=["PUT", "DELETE"])
@@ -746,6 +842,8 @@ def goal_detail(goal_id):
             return jsonify({"error": "Goal not found"}), 404
 
         if request.method == "DELETE":
+            # Delete milestones first
+            FinancialGoalMilestone.query.filter_by(goal_id=goal.id).delete(synchronize_session=False)
             db.session.delete(goal)
             db.session.commit()
             return jsonify({"status": "success"})
@@ -762,11 +860,16 @@ def goal_detail(goal_id):
             if "target_date" in data:
                 goal.target_date = validate_string(data["target_date"], "target_date")
             db.session.commit()
+
+            milestones = compute_monthly_milestones(goal)
+            persist_goal_milestones(goal, milestones)
+
             return jsonify({"status": "success", "goal": goal.to_dict()})
     except ValidationError as e:
         raise e
     except Exception as e:
         return jsonify({"error": str(e)}), 400
+
 
 
 @app.route("/api/goals", methods=["GET"])

--- a/app.py
+++ b/app.py
@@ -380,6 +380,112 @@ def tax():
         return jsonify({"error": str(e)}), 400
 
 
+@app.route("/tax/simulate", methods=["POST"])
+def tax_simulate():
+    try:
+        from utils.tax import simulate_tax_scenarios
+
+        data = request.json or {}
+        if not isinstance(data, dict):
+            raise ValidationError("Request body must be a JSON object")
+
+        income = validate_float(data.get("income"), "income", min_val=0.0)
+
+        scenario_a = data.get("scenario_a") or {}
+        scenario_b = data.get("scenario_b") or {}
+
+        if not isinstance(scenario_a, dict) or not isinstance(scenario_b, dict):
+            raise ValidationError("'scenario_a' and 'scenario_b' must be objects")
+
+        scenario_a_d80c = validate_float(scenario_a.get("deduction_80c", 0.0), "scenario_a.deduction_80c", min_val=0.0)
+        scenario_a_d80d = validate_float(scenario_a.get("deduction_80d", 0.0), "scenario_a.deduction_80d", min_val=0.0)
+        scenario_a_hra = validate_float(scenario_a.get("deduction_hra", 0.0), "scenario_a.deduction_hra", min_val=0.0)
+
+        scenario_b_d80c = validate_float(scenario_b.get("deduction_80c", 0.0), "scenario_b.deduction_80c", min_val=0.0)
+        scenario_b_d80d = validate_float(scenario_b.get("deduction_80d", 0.0), "scenario_b.deduction_80d", min_val=0.0)
+        scenario_b_hra = validate_float(scenario_b.get("deduction_hra", 0.0), "scenario_b.deduction_hra", min_val=0.0)
+
+        result = simulate_tax_scenarios(
+            income,
+            scenario_a={
+                "deduction_80c": scenario_a_d80c,
+                "deduction_80d": scenario_a_d80d,
+                "deduction_hra": scenario_a_hra,
+            },
+            scenario_b={
+                "deduction_80c": scenario_b_d80c,
+                "deduction_80d": scenario_b_d80d,
+                "deduction_hra": scenario_b_hra,
+            },
+        )
+
+        # Deterministic explanation always available
+        best_regime_a = result["best_regime"]["scenario_a"]
+        best_regime_b = result["best_regime"]["scenario_b"]
+        switch_savings_new = float(result["comparison"]["switch"]["new_regime"]["savings"])
+        switch_savings_old = float(result["comparison"]["switch"]["old_regime"]["savings"])
+
+        # pick regime under which switching A->B saves more (deterministic)
+        if switch_savings_new >= switch_savings_old and switch_savings_new > 0:
+            regime_for_explanation = "New Regime"
+        elif switch_savings_old > 0:
+            regime_for_explanation = "Old Regime"
+        else:
+            regime_for_explanation = result["comparison"]["best_scenario_by_savings_under_recommended_regime"]
+
+        # Build deterministic lever explanation from sensitivity rankings for the best regime of scenario B
+        scenario_b_best = best_regime_b
+        sens_for_scenario_b = result["sensitivity"]["scenario_b"]["new_regime"] if scenario_b_best == "New Regime" else result["sensitivity"]["scenario_b"]["old_regime"]
+        lever_ranking = result["sensitivity"]["scenario_b"]["new_regime"]["lever_ranking_for_best_regime"] if scenario_b_best == "New Regime" else result["sensitivity"]["scenario_b"]["old_regime"]["lever_ranking_for_best_regime"]
+
+        deterministic_explanation = (
+            f"Regime outcome: Scenario A is better under {best_regime_a}, while Scenario B is better under {best_regime_b}. "
+            f"Under {scenario_b_best}, the biggest tax lever tends to be: {lever_ranking[0]['lever']} "
+            f"(≈ {abs(lever_ranking[0]['delta_per_1']):.2f} tax change per ₹1). "
+        )
+
+        if client:
+            # AI explanation prompt (use computed deltas + savings)
+            prompt = (
+                f"User wants to compare tax scenarios in India.\n\n"
+                f"Income: ₹{result['income']:.0f}\n\n"
+                f"Scenario A recommended regime: {best_regime_a}\n"
+                f"Scenario B recommended regime: {best_regime_b}\n\n"
+                f"Switching A -> B savings:\n"
+                f"- New regime savings: ₹{switch_savings_new:.2f}\n"
+                f"- Old regime savings: ₹{switch_savings_old:.2f}\n\n"
+                f"Sensitivity (Scenario B, per ₹1 increase):\n"
+                f"{lever_ranking}\n\n"
+                f"Explain in simple terms why the winning regime is likely to be {best_regime_b} "
+                f"and which levers (80C/80D/HRA) give the biggest savings. "
+                f"Use bullet points and keep it under 8 lines."
+            )
+            try:
+                ai_res = client.chat.completions.create(
+                    model="llama-3.1-8b-instant",
+                    messages=[
+                        {"role": "system", "content": "You are a professional Indian tax consultant. Provide concise, actionable insights."},
+                        {"role": "user", "content": prompt},
+                    ],
+                )
+                explanation = ai_res.choices[0].message.content.strip()
+            except Exception as ai_err:
+                app.logger.error(f"Tax simulate AI error: {str(ai_err)}")
+                explanation = deterministic_explanation
+        else:
+            explanation = deterministic_explanation
+
+        result["explanation"] = explanation
+        result["ai_available"] = client is not None
+
+        return jsonify({"result": result})
+
+    except ValidationError as e:
+        raise e
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
 # ---------------- 📄 PDF ----------------
 @app.route("/upload", methods=["POST"])
 def upload():

--- a/models.py
+++ b/models.py
@@ -158,6 +158,9 @@ class FinancialGoal(db.Model):
     target_amount = db.Column(db.Float, nullable=False)
     current_amount = db.Column(db.Float, nullable=False, default=0.0)
     target_date = db.Column(db.String(10), nullable=False)  # YYYY-MM
+
+    # Optional AI-generated plan/tactics
+    ai_milestone_tactics = db.Column(db.Text, nullable=True)  # plain text, 3-5 bullet points
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     def to_dict(self):
@@ -171,3 +174,25 @@ class FinancialGoal(db.Model):
             "target_date": self.target_date,
             "created_at": self.created_at.isoformat() if self.created_at else None
         }
+
+
+class FinancialGoalMilestone(db.Model):
+    __tablename__ = "financial_goal_milestones"
+    id = db.Column(db.Integer, primary_key=True)
+    goal_id = db.Column(db.Integer, db.ForeignKey("financial_goals.id"), nullable=False, index=True)
+    month = db.Column(db.String(7), nullable=False)  # YYYY-MM
+    target_amount_for_month = db.Column(db.Float, nullable=False, default=0.0)
+    status = db.Column(db.String(20), nullable=False, default="planned")  # planned|completed
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "goal_id": self.goal_id,
+            "month": self.month,
+            "target_amount_for_month": self.target_amount_for_month,
+            "status": self.status,
+        }
+
+
+

--- a/templates/tax.html
+++ b/templates/tax.html
@@ -4,152 +4,258 @@
 
 {% block content %}
 <div id="tax" class="page active">
-  <div class="page-title">💸 Tax <span>Planner</span></div>
-  <div style="display: grid; grid-template-columns: 1fr 1.5fr; gap: 20px; align-items: start; max-width: 950px;"    <div class="card">
-      <div class="card-title">Income Tax Calculator (Old vs New Regime)</div>
+  <div class="page-title">💸 Tax <span>Scenario Simulator</span></div>
+
+  <div style="display: grid; grid-template-columns: 1fr 1.6fr; gap: 20px; align-items: start; max-width: 1100px;">
+    <!-- Left: Inputs -->
+    <div class="card">
+      <div class="card-title">Scenario Inputs (Old vs New Regime)</div>
+
       <label>Gross Annual Income (₹)</label>
-      <input type="number" required min="0" id="taxIncome" placeholder="e.g. 1200000" style="margin-bottom:12px;">
+      <input type="number" required min="0" id="taxIncome" placeholder="e.g. 1200000" style="margin-bottom:14px;">
 
-      <label>Section 80C Deductions (₹)</label>
-      <input type="number" min="0" max="150000" id="tax80c" placeholder="e.g. 150000 (PPF, ELSS, EPF)" style="margin-bottom:12px;">
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-bottom:14px;">
+        <div style="padding:12px; border:1px solid var(--border); border-radius:12px;">
+          <div style="font-weight:800; margin-bottom:10px;">Scenario A</div>
 
-      <label>Section 80D Deductions (₹)</label>
-      <input type="number" min="0" max="25000" id="tax80d" placeholder="e.g. 25000 (Health Insurance)" style="margin-bottom:12px;">
+          <label>80C (₹)</label>
+          <input type="number" min="0" max="150000" id="taxA80c" style="width:100%; margin-bottom:10px;"
+                 placeholder="e.g. 80000">
 
-      <label>HRA Deductions (₹)</label>
-      <input type="number" min="0" id="taxHra" placeholder="e.g. 50000" style="margin-bottom:12px;">
+          <label>80D (₹)</label>
+          <input type="number" min="0" max="25000" id="taxA80d" style="width:100%; margin-bottom:10px;"
+                 placeholder="e.g. 25000">
+
+          <label>HRA (₹)</label>
+          <input type="number" min="0" id="taxAhra" style="width:100%; margin-bottom:0px;"
+                 placeholder="e.g. 50000">
+        </div>
+
+        <div style="padding:12px; border:1px solid var(--border); border-radius:12px;">
+          <div style="font-weight:800; margin-bottom:10px;">Scenario B</div>
+
+          <label>80C (₹)</label>
+          <input type="number" min="0" max="150000" id="taxB80c" style="width:100%; margin-bottom:10px;"
+                 placeholder="e.g. 120000">
+
+          <label>80D (₹)</label>
+          <input type="number" min="0" max="25000" id="taxB80d" style="width:100%; margin-bottom:10px;"
+                 placeholder="e.g. 10000">
+
+          <label>HRA (₹)</label>
+          <input type="number" min="0" id="taxBhra" style="width:100%; margin-bottom:0px;"
+                 placeholder="e.g. 50000">
+        </div>
 
       <div style="display:flex;gap:10px;margin-top:16px;">
-        <button class="btn btn-gold" style="flex:1" onclick="calcTax()" id="taxBtn">Calculate Tax</button>
+        <button class="btn btn-gold" style="flex:1" onclick="simulateTax()" id="taxBtn">Simulate</button>
         <button class="btn btn-ghost" style="flex:1" onclick="resetTax()" id="taxResetBtn">Reset</button>
       </div>
-      <div id="taxResult" class="result-box"></div>
-    </div>
+
+      <div id="taxResult" class="result-box" style="margin-top:16px;"></div>
+
+    <!-- Right: Outputs -->
     <div class="card" id="taxComparisonCard" style="display:none; min-height: 280px;">
-      <div class="card-title">Regime Comparison (Old vs. New)</div>
-      <div id="taxComparisonResult"></div>
-    </div>
+      <div class="card-title">Scenario Comparison (Old vs New)</div>
+
+      <div id="deltaCard" style="display:none; margin-top:12px;"></div>
+
+      <div style="margin-top:14px;">
+        <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px;">
+          <div style="padding:12px; border:1px solid var(--border); border-radius:12px;">
+            <div style="font-weight:900; margin-bottom:10px;">Scenario A</div>
+            <div id="scenarioAResult"></div>
+
+          <div style="padding:12px; border:1px solid var(--border); border-radius:12px;">
+            <div style="font-weight:900; margin-bottom:10px;">Scenario B</div>
+            <div id="scenarioBResult"></div>
+        </div>
+
+      <div id="explanationBox" style="margin-top:16px; display:none;"></div>
   </div>
-</div>
 {% endblock %}
 
 {% block scripts %}
 <script>
-  async function calcTax() {
-    const income = document.getElementById('taxIncome').value;
-    if (!income) { showResult('taxResult', '⚠ Enter your annual income.'); return; }
+  function escapeHtml(str) {
+    return String(str)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '<')
+      .replaceAll('>', '>')
+      .replaceAll('"', '"')
+      .replaceAll("'", '&#039;');
+  }
 
-    const deduction_80c = document.getElementById('tax80c').value || 0;
-    const deduction_80d = document.getElementById('tax80d').value || 0;
-    const deduction_hra = document.getElementById('taxHra').value || 0;
+  function renderRegimeSummaryTable(taxRes) {
+    return `
+      <table style="width:100%; border-collapse:collapse; font-size:13px; text-align:left; color:var(--text);">
+        <thead>
+          <tr style="border-bottom:1px solid var(--border); color:var(--muted); font-size:11px; text-transform:uppercase;">
+            <th style="padding:10px 0;">Particulars</th>
+            <th style="padding:10px 0;">Old Regime</th>
+            <th style="padding:10px 0; color:var(--gold);">New Regime</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr style="border-bottom:1px solid var(--border);">
+            <td style="padding:10px 0;">Gross Income</td>
+            <td style="padding:10px 0;">₹${fmtNum(taxRes.gross_income)}</td>
+            <td style="padding:10px 0; color:var(--gold);">₹${fmtNum(taxRes.gross_income)}</td>
+          </tr>
+          <tr style="border-bottom:1px solid var(--border);">
+            <td style="padding:10px 0;">Std Deduction</td>
+            <td style="padding:10px 0;">-₹${fmtNum(taxRes.old_regime.standard_deduction)}</td>
+            <td style="padding:10px 0; color:var(--gold);">-₹${fmtNum(taxRes.new_regime.standard_deduction)}</td>
+          </tr>
+          <tr style="border-bottom:1px solid var(--border);">
+            <td style="padding:10px 0;">Taxable Income</td>
+            <td style="padding:10px 0;">₹${fmtNum(taxRes.old_regime.taxable_income)}</td>
+            <td style="padding:10px 0; color:var(--gold);">₹${fmtNum(taxRes.new_regime.taxable_income)}</td>
+          </tr>
+          <tr style="border-bottom:1px solid var(--border);">
+            <td style="padding:10px 0;">Cess (4%)</td>
+            <td style="padding:10px 0;">₹${fmtNum(taxRes.old_regime.cess)}</td>
+            <td style="padding:10px 0; color:var(--gold);">₹${fmtNum(taxRes.new_regime.cess)}</td>
+          </tr>
+          <tr style="font-weight:700; font-size:15px; border-bottom:2px solid var(--border);">
+            <td style="padding:12px 0;">Total Tax</td>
+            <td style="padding:12px 0;">₹${fmtNum(taxRes.old_regime.total_tax)}</td>
+            <td style="padding:12px 0; color:#2ecc8a;">₹${fmtNum(taxRes.new_regime.total_tax)}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div style="margin-top:12px; padding:10px 12px; background:rgba(46,204,138,0.08); border:1px solid rgba(46,204,138,0.2); border-radius:10px; color:#2ecc8a; font-size:13px; line-height:1.5;">
+        <strong>Recommendation:</strong> Select <strong>${taxRes.recommended}</strong><br/>
+        Annual Savings: <strong>₹${fmtNum(taxRes.savings)}</strong>
+      </div>
+    `;
+  }
+
+  async function simulateTax() {
+    const incomeRaw = document.getElementById('taxIncome').value;
+    if (!incomeRaw) {
+      showResult('taxResult', '⚠ Enter your annual income.');
+      return;
+    }
+
+    const scenarioA = {
+      deduction_80c: parseFloat(document.getElementById('taxA80c').value || 0),
+      deduction_80d: parseFloat(document.getElementById('taxA80d').value || 0),
+      deduction_hra: parseFloat(document.getElementById('taxAhra').value || 0),
+    };
+
+    const scenarioB = {
+      deduction_80c: parseFloat(document.getElementById('taxB80c').value || 0),
+      deduction_80d: parseFloat(document.getElementById('taxB80d').value || 0),
+      deduction_hra: parseFloat(document.getElementById('taxBhra').value || 0),
+    };
 
     setLoading('taxBtn', true);
     try {
-      const data = await apiFetch('/tax', { 
-        income: parseFloat(income),
-        deduction_80c: parseFloat(deduction_80c),
-        deduction_80d: parseFloat(deduction_80d),
-        deduction_hra: parseFloat(deduction_hra)
+      const res = await apiFetch('/tax/simulate', {
+        income: parseFloat(incomeRaw),
+        scenario_a: scenarioA,
+        scenario_b: scenarioB,
       });
 
-      if (data.error) {
-        showResult('taxResult', `⚠ ${data.error}`);
-      } else {
-        const taxRes = data.tax;
-        document.getElementById('taxComparisonCard').style.display = 'block';
-
-        let tableHtml = `
-          <table style="width:100%; border-collapse:collapse; font-size:13px; text-align:left; color:var(--text);">
-            <thead>
-              <tr style="border-bottom:1px solid var(--border); color:var(--muted); font-size:11px; text-transform:uppercase;">
-                <th style="padding:10px 0;">Particulars</th>
-                <th style="padding:10px 0;">Old Regime</th>
-                <th style="padding:10px 0; color:var(--gold);">New Regime</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr style="border-bottom:1px solid var(--border);">
-                <td style="padding:10px 0;">Gross Income</td>
-                <td style="padding:10px 0;">₹${fmtNum(taxRes.gross_income)}</td>
-                <td style="padding:10px 0; color:var(--gold);">₹${fmtNum(taxRes.gross_income)}</td>
-              </tr>
-              <tr style="border-bottom:1px solid var(--border);">
-                <td style="padding:10px 0;">Std Deduction</td>
-                <td style="padding:10px 0;">-₹${fmtNum(taxRes.old_regime.standard_deduction)}</td>
-                <td style="padding:10px 0; color:var(--gold);">-₹${fmtNum(taxRes.new_regime.standard_deduction)}</td>
-              </tr>
-              <tr style="border-bottom:1px solid var(--border);">
-                <td style="padding:10px 0;">Taxable Income</td>
-                <td style="padding:10px 0;">₹${fmtNum(taxRes.old_regime.taxable_income)}</td>
-                <td style="padding:10px 0; color:var(--gold);">₹${fmtNum(taxRes.new_regime.taxable_income)}</td>
-              </tr>
-              <tr style="border-bottom:1px solid var(--border);">
-                <td style="padding:10px 0;">Base Tax</td>
-                <td style="padding:10px 0;">₹${fmtNum(taxRes.old_regime.base_tax)}</td>
-                <td style="padding:10px 0; color:var(--gold);">₹${fmtNum(taxRes.new_regime.base_tax)}</td>
-              </tr>
-              <tr style="border-bottom:1px solid var(--border);">
-                <td style="padding:10px 0;">Cess (4%)</td>
-                <td style="padding:10px 0;">₹${fmtNum(taxRes.old_regime.cess)}</td>
-                <td style="padding:10px 0; color:var(--gold);">₹${fmtNum(taxRes.new_regime.cess)}</td>
-              </tr>
-              <tr style="font-weight:700; font-size:15px; border-bottom:2px solid var(--border);">
-                <td style="padding:12px 0;">Total Tax</td>
-                <td style="padding:12px 0;">₹${fmtNum(taxRes.old_regime.total_tax)}</td>
-                <td style="padding:12px 0; color:#2ecc8a;">₹${fmtNum(taxRes.new_regime.total_tax)}</td>
-              </tr>
-            </tbody>
-          </table>
-          
-          <div style="margin-top:16px; padding:12px 14px; background:rgba(46,204,138,0.08); border:1px solid rgba(46,204,138,0.2); border-radius:8px; color:#2ecc8a; font-size:13px; line-height:1.5;">
-            <strong>Recommendation:</strong> Select the <strong>${taxRes.recommended}</strong>.<br/>
-            You will save <strong>₹${fmtNum(taxRes.savings)}</strong> annually with this regime.
-          </div>
-        `;
-
-        // Format AI tax-saving advice
-        let aiAdviceHtml = "";
-        if (taxRes.ai_recommendations) {
-          let formattedAdvice = taxRes.ai_recommendations
-            .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-            .replace(/\n/g, '<br/>');
-          
-          aiAdviceHtml = `
-            <div style="margin-top: 18px; padding: 16px; background: rgba(212, 168, 67, 0.05); border: 1px solid rgba(212, 168, 67, 0.15); border-radius: 12px; text-align: left;">
-              <div style="font-family:'Syne',sans-serif; font-size: 14px; font-weight: 700; color: var(--gold2); margin-bottom: 8px; display: flex; align-items: center; gap: 6px;">
-                <span>💡 AI Tax-Saving Tips</span>
-              </div>
-              <div style="font-size: 13px; line-height: 1.6; color: var(--text);">
-                ${formattedAdvice}
-              </div>
-            </div>
-          `;
-        }
-
-        document.getElementById('taxComparisonResult').innerHTML = tableHtml + aiAdviceHtml;
-
-        showResult('taxResult', `
-          <div style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em">Tax Payable (${taxRes.recommended})</div>
-          <div class="result-big" style="color:#2ecc8a;">₹${fmtNum(taxRes.recommended === "New Regime" ? taxRes.new_regime.total_tax : taxRes.old_regime.total_tax)}</div>
-          <div style="font-size:12px;color:var(--muted);margin-top:4px">Annual Savings: ₹${fmtNum(taxRes.savings)}</div>
-        `);
+      if (res.error) {
+        showResult('taxResult', `⚠ ${res.error}`);
+        return;
       }
+
+      const result = res.result || {};
+      const taxA = result.scenario_a || {};
+      const taxB = result.scenario_b || {};
+
+      document.getElementById('taxComparisonCard').style.display = 'block';
+
+      document.getElementById('scenarioAResult').innerHTML = renderRegimeSummaryTable(taxA);
+      document.getElementById('scenarioBResult').innerHTML = renderRegimeSummaryTable(taxB);
+
+      // Delta card: switching A -> B savings
+      const deltaNew = Number(result.comparison?.switch?.new_regime?.savings || 0);
+      const deltaOld = Number(result.comparison?.switch?.old_regime?.savings || 0);
+
+      let deltaText = '';
+      if (deltaNew > 0) {
+        deltaText = `Switching deduction amounts saves <strong>₹${fmtNum(deltaNew)}</strong> under <strong>New Regime</strong>.`;
+      } else if (deltaOld > 0) {
+        deltaText = `Switching deduction amounts saves <strong>₹${fmtNum(deltaOld)}</strong> under <strong>Old Regime</strong>.`;
+      } else {
+        deltaText = `Switching deductions does not reduce tax under either regime for this income.`;
+      }
+
+      const deltaCard = document.getElementById('deltaCard');
+      deltaCard.style.display = 'block';
+      deltaCard.innerHTML = `
+        <div style="padding:14px 14px; background:rgba(212, 168, 67, 0.07); border:1px solid rgba(212, 168, 67, 0.18); border-radius:12px; color: var(--gold2); font-size:13px; line-height:1.5;">
+          <strong>Δ Switch Card:</strong> ${deltaText}
+        </div>
+      `;
+
+      // Explanation box (AI or deterministic)
+      const explanation = result.explanation || '';
+      const explanationBox = document.getElementById('explanationBox');
+      explanationBox.style.display = 'block';
+      explanationBox.innerHTML = `
+        <div style="margin-top:12px; padding:14px 14px; background: rgba(212, 168, 67, 0.05); border:1px solid rgba(212, 168, 67, 0.15); border-radius:12px; color: var(--text); font-size:13px; line-height:1.6; text-align:left;">
+          <div style="font-weight:900; margin-bottom:8px;">🧠 AI/Offline Explanation</div>
+          <div>${escapeHtml(explanation).replace(/\\n/g, '<br/>')}</div>
+      `;
+
+      // Show payable for Scenario B recommended regime
+      const recommendedB = taxB.recommended || 'New Regime';
+      const payableB = recommendedB === 'New Regime' ? taxB.new_regime.total_tax : taxB.old_regime.total_tax;
+
+      showResult('taxResult', `
+        <div style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em">
+          Payable (Scenario B • ${recommendedB})
+        </div>
+        <div class="result-big" style="color:#2ecc8a;">₹${fmtNum(payableB || 0)}</div>
+        <div style="font-size:12px;color:var(--muted);margin-top:4px">
+          Annual Savings (vs other regime): ₹${fmtNum(taxB.savings || 0)}
+        </div>
+      `);
+
     } catch (e) {
       showResult('taxResult', '⚠ Could not reach server.');
+    } finally {
+      setLoading('taxBtn', false);
     }
-    setLoading('taxBtn', false);
   }
 
   function resetTax() {
     document.getElementById('taxIncome').value = '';
-    document.getElementById('tax80c').value = '';
-    document.getElementById('tax80d').value = '';
-    document.getElementById('taxHra').value = '';
+    document.getElementById('taxA80c').value = '';
+    document.getElementById('taxA80d').value = '';
+    document.getElementById('taxAhra').value = '';
+    document.getElementById('taxB80c').value = '';
+    document.getElementById('taxB80d').value = '';
+    document.getElementById('taxBhra').value = '';
+
     const res = document.getElementById('taxResult');
     res.innerHTML = '';
-    res.classList.remove('visible');
+
     const compCard = document.getElementById('taxComparisonCard');
     if (compCard) compCard.style.display = 'none';
+
+    const deltaCard = document.getElementById('deltaCard');
+    if (deltaCard) {
+      deltaCard.style.display = 'none';
+      deltaCard.innerHTML = '';
+    }
+
+    const expBox = document.getElementById('explanationBox');
+    if (expBox) {
+      expBox.style.display = 'none';
+      expBox.innerHTML = '';
+    }
+
+    const aBox = document.getElementById('scenarioAResult');
+    const bBox = document.getElementById('scenarioBResult');
+    if (aBox) aBox.innerHTML = '';
+    if (bBox) bBox.innerHTML = '';
   }
 </script>
 {% endblock %}

--- a/utils/tax.py
+++ b/utils/tax.py
@@ -92,4 +92,163 @@ def calculate_tax(income, deduction_80c=0.0, deduction_80d=0.0, deduction_hra=0.
         "recommended": "New Regime" if total_new < total_old else "Old Regime",
         "savings": round(abs(total_old - total_new), 2)
     }
-
+
+
+def _r2(x):
+    return round(float(x), 2)
+
+
+def _tax_total_for_regime(calc_result, regime_key):
+    return float(calc_result[regime_key]["total_tax"])
+
+
+def _sensitivity_by_rupee(income, deduction_80c=0.0, deduction_80d=0.0, deduction_hra=0.0):
+    """
+    Returns marginal tax deltas per ₹1 change in each deduction, computed via
+    finite difference: tax(d+1) - tax(d). Caps in calculate_tax naturally apply.
+    """
+    base = calculate_tax(income, deduction_80c=deduction_80c, deduction_80d=deduction_80d, deduction_hra=deduction_hra)
+
+    deltas = {
+        "new_regime": {"80c_delta_per_1": 0.0, "80d_delta_per_1": 0.0, "hra_delta_per_1": 0.0},
+        "old_regime": {"80c_delta_per_1": 0.0, "80d_delta_per_1": 0.0, "hra_delta_per_1": 0.0},
+    }
+
+    # 80C (+1)
+    plus_80c = calculate_tax(income, deduction_80c=deduction_80c + 1, deduction_80d=deduction_80d, deduction_hra=deduction_hra)
+    deltas["new_regime"]["80c_delta_per_1"] = _r2(_tax_total_for_regime(plus_80c, "new_regime") - _tax_total_for_regime(base, "new_regime"))
+    deltas["old_regime"]["80c_delta_per_1"] = _r2(_tax_total_for_regime(plus_80c, "old_regime") - _tax_total_for_regime(base, "old_regime"))
+
+    # 80D (+1)
+    plus_80d = calculate_tax(income, deduction_80c=deduction_80c, deduction_80d=deduction_80d + 1, deduction_hra=deduction_hra)
+    deltas["new_regime"]["80d_delta_per_1"] = _r2(_tax_total_for_regime(plus_80d, "new_regime") - _tax_total_for_regime(base, "new_regime"))
+    deltas["old_regime"]["80d_delta_per_1"] = _r2(_tax_total_for_regime(plus_80d, "old_regime") - _tax_total_for_regime(base, "old_regime"))
+
+    # HRA (+1)
+    plus_hra = calculate_tax(income, deduction_80c=deduction_80c, deduction_80d=deduction_80d, deduction_hra=deduction_hra + 1)
+    deltas["new_regime"]["hra_delta_per_1"] = _r2(_tax_total_for_regime(plus_hra, "new_regime") - _tax_total_for_regime(base, "new_regime"))
+    deltas["old_regime"]["hra_delta_per_1"] = _r2(_tax_total_for_regime(plus_hra, "old_regime") - _tax_total_for_regime(base, "old_regime"))
+
+    return deltas
+
+
+def simulate_tax_scenarios(
+    income,
+    scenario_a,
+    scenario_b,
+):
+    """
+    scenario_a / scenario_b are dicts with:
+      - deduction_80c
+      - deduction_80d
+      - deduction_hra
+
+    Returns deterministic output:
+      - scenario_a: full calculate_tax output
+      - scenario_b: full calculate_tax output
+      - scenario switch deltas (A -> B): total tax deltas per regime
+      - sensitivity deltas per ₹1 change in each deduction for each scenario+regime
+      - deterministic lever ranking for offline explanation
+    """
+    def _pick(sc):
+        return {
+            "deduction_80c": float(sc.get("deduction_80c", 0.0)),
+            "deduction_80d": float(sc.get("deduction_80d", 0.0)),
+            "deduction_hra": float(sc.get("deduction_hra", 0.0)),
+        }
+
+    a_in = _pick(scenario_a)
+    b_in = _pick(scenario_b)
+
+    a_calc = calculate_tax(
+        income,
+        deduction_80c=a_in["deduction_80c"],
+        deduction_80d=a_in["deduction_80d"],
+        deduction_hra=a_in["deduction_hra"],
+    )
+    b_calc = calculate_tax(
+        income,
+        deduction_80c=b_in["deduction_80c"],
+        deduction_80d=b_in["deduction_80d"],
+        deduction_hra=b_in["deduction_hra"],
+    )
+
+    # Switching A -> B deltas (B - A)
+    delta_new_total = _r2(b_calc["new_regime"]["total_tax"] - a_calc["new_regime"]["total_tax"])
+    delta_old_total = _r2(b_calc["old_regime"]["total_tax"] - a_calc["old_regime"]["total_tax"])
+
+    # "Savings under new regime" when switching A -> B
+    # If delta is negative, B saves; we report positive savings amount.
+    new_savings_switch = _r2(max(0.0, -delta_new_total))
+    old_savings_switch = _r2(max(0.0, -delta_old_total))
+
+    # Sensitivity (per ₹1 change) for each scenario
+    a_sens = _sensitivity_by_rupee(
+        income,
+        deduction_80c=a_in["deduction_80c"],
+        deduction_80d=a_in["deduction_80d"],
+        deduction_hra=a_in["deduction_hra"],
+    )
+    b_sens = _sensitivity_by_rupee(
+        income,
+        deduction_80c=b_in["deduction_80c"],
+        deduction_80d=b_in["deduction_80d"],
+        deduction_hra=b_in["deduction_hra"],
+    )
+
+    def _rank_levers(sens_for_regime):
+        # Most negative delta per ₹1 reduces tax (best). If all >=0, still return largest deltas first.
+        candidates = [
+            ("80C", sens_for_regime["80c_delta_per_1"]),
+            ("80D", sens_for_regime["80d_delta_per_1"]),
+            ("HRA", sens_for_regime["hra_delta_per_1"]),
+        ]
+        candidates_sorted = sorted(candidates, key=lambda x: x[1])  # ascending (more negative first)
+        return [
+            {
+                "lever": name,
+                "delta_per_1": float(delta),
+            }
+            for name, delta in candidates_sorted
+        ]
+
+    best_regime_a = a_calc["recommended"]
+    best_regime_b = b_calc["recommended"]
+
+    # For deterministic offline explanation, choose lever ranking for each scenario's recommended regime.
+    sens_a_for_best = a_sens["new_regime"] if best_regime_a == "New Regime" else a_sens["old_regime"]
+    sens_b_for_best = b_sens["new_regime"] if best_regime_b == "New Regime" else b_sens["old_regime"]
+
+    comparison = {
+        "switch": {
+            "new_regime": {"delta_total_tax": delta_new_total, "savings": new_savings_switch},
+            "old_regime": {"delta_total_tax": delta_old_total, "savings": old_savings_switch},
+        },
+        "best_scenario_by_savings_under_recommended_regime": (
+            "A" if (a_calc["savings"] >= b_calc["savings"]) else "B"
+        ),
+        "best_regime": {
+            "scenario_a": best_regime_a,
+            "scenario_b": best_regime_b,
+        },
+    }
+
+    return {
+        "income": float(income),
+        "scenario_a": a_calc,
+        "scenario_b": b_calc,
+        "comparison": comparison,
+        "sensitivity": {
+            "scenario_a": {
+                "new_regime": a_sens["new_regime"],
+                "old_regime": a_sens["old_regime"],
+                "lever_ranking_for_best_regime": _rank_levers(sens_a_for_best),
+            },
+            "scenario_b": {
+                "new_regime": b_sens["new_regime"],
+                "old_regime": b_sens["old_regime"],
+                "lever_ranking_for_best_regime": _rank_levers(sens_b_for_best),
+            },
+        },
+    }
+


### PR DESCRIPTION
Updated templates/tax.html with a clean, complete “Scenario A / Scenario B” UI and working client-side logic that calls POST /tax/simulate, renders both scenario tables, shows the required delta/switch card, and displays the explanation (AI or offline deterministic).



closes #253