### PR TITLE
Feature : Add CSV/PDF financial report export (#282)

### DIFF
--- a/app.py
+++ b/app.py
@@ -479,8 +479,8 @@ def tax_simulate():
         )
 
         # Deterministic explanation always available
-        best_regime_a = result["best_regime"]["scenario_a"]
-        best_regime_b = result["best_regime"]["scenario_b"]
+        best_regime_a = result["comparison"]["best_regime"]["scenario_a"]
+        best_regime_b = result["comparison"]["best_regime"]["scenario_b"]
         switch_savings_new = float(result["comparison"]["switch"]["new_regime"]["savings"])
         switch_savings_old = float(result["comparison"]["switch"]["old_regime"]["savings"])
 
@@ -494,8 +494,7 @@ def tax_simulate():
 
         # Build deterministic lever explanation from sensitivity rankings for the best regime of scenario B
         scenario_b_best = best_regime_b
-        sens_for_scenario_b = result["sensitivity"]["scenario_b"]["new_regime"] if scenario_b_best == "New Regime" else result["sensitivity"]["scenario_b"]["old_regime"]
-        lever_ranking = result["sensitivity"]["scenario_b"]["new_regime"]["lever_ranking_for_best_regime"] if scenario_b_best == "New Regime" else result["sensitivity"]["scenario_b"]["old_regime"]["lever_ranking_for_best_regime"]
+        lever_ranking = result["sensitivity"]["scenario_b"]["lever_ranking_for_best_regime"]
 
         deterministic_explanation = (
             f"Regime outcome: Scenario A is better under {best_regime_a}, while Scenario B is better under {best_regime_b}. "

--- a/app.py
+++ b/app.py
@@ -1,8 +1,11 @@
-from flask import Flask, request, jsonify, render_template
+from flask import Flask, request, jsonify, render_template, make_response
 import yfinance as yf
 import os
 import sys
+import csv
+import io
 from groq import Groq
+from fpdf import FPDF
 from dotenv import load_dotenv
 
 # Load environment variables from .env file (if present)
@@ -614,6 +617,72 @@ def money_score():
 
     except ValidationError as e:
         raise e
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+# ---------------- EXPORT FINANCIAL REPORT ----------------
+EXPORT_FIELDS = [
+    "income", "expenses", "savings", "investments",
+    "debt", "emergency", "tax", "money_score", "sip_projection",
+]
+
+EXPORT_FIELD_LABELS = {
+    "income": "Income",
+    "expenses": "Expenses",
+    "savings": "Savings",
+    "investments": "Investments",
+    "debt": "Debt",
+    "emergency": "Emergency Fund",
+    "tax": "Tax Estimate",
+    "money_score": "Money Score",
+    "sip_projection": "SIP Projection",
+}
+
+
+def _pdf_safe(value):
+    """Strip characters (e.g. ₹, emoji) that core PDF fonts can't encode."""
+    return str(value).replace("₹", "Rs. ").encode("latin-1", "ignore").decode("latin-1")
+
+
+@app.route("/export/csv", methods=["POST"])
+def export_csv():
+    try:
+        data = request.json or {}
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=EXPORT_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerow({field: data.get(field, "N/A") for field in EXPORT_FIELDS})
+
+        response = make_response(output.getvalue())
+        response.headers["Content-Disposition"] = "attachment; filename=financial_report.csv"
+        response.headers["Content-Type"] = "text/csv"
+        return response
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@app.route("/export/pdf", methods=["POST"])
+def export_pdf():
+    try:
+        data = request.json or {}
+
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Helvetica", "B", 16)
+        pdf.cell(0, 10, "AI Money Mentor - Financial Report", new_x="LMARGIN", new_y="NEXT", align="C")
+        pdf.ln(5)
+
+        pdf.set_font("Helvetica", size=12)
+        for key in EXPORT_FIELDS:
+            value = _pdf_safe(data.get(key, "N/A"))
+            pdf.cell(0, 10, f"{EXPORT_FIELD_LABELS[key]}: {value}", new_x="LMARGIN", new_y="NEXT")
+
+        pdf_bytes = bytes(pdf.output())
+        response = make_response(pdf_bytes)
+        response.headers["Content-Disposition"] = "attachment; filename=financial_report.pdf"
+        response.headers["Content-Type"] = "application/pdf"
+        return response
     except Exception as e:
         return jsonify({"error": str(e)}), 400
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.2.2
 pytest
 flask-sqlalchemy==3.1.1
 apscheduler
+fpdf2

--- a/templates/base.html
+++ b/templates/base.html
@@ -128,6 +128,55 @@
       const res = await fetch(url, opts);
       return res.json();
     }
+
+    // ---- Financial report export (merges results across pages via localStorage) ----
+    const FINANCIAL_REPORT_KEY = 'financialReportData';
+
+    function updateReportData(partial) {
+      let data = {};
+      try {
+        data = JSON.parse(localStorage.getItem(FINANCIAL_REPORT_KEY)) || {};
+      } catch (e) {}
+      Object.assign(data, partial);
+      localStorage.setItem(FINANCIAL_REPORT_KEY, JSON.stringify(data));
+      return data;
+    }
+
+    function getReportData() {
+      try {
+        return JSON.parse(localStorage.getItem(FINANCIAL_REPORT_KEY)) || {};
+      } catch (e) {
+        return {};
+      }
+    }
+
+    function showExportSection() {
+      const el = document.getElementById('export-section');
+      if (el) el.style.display = 'flex';
+    }
+
+    async function exportReport(format) {
+      try {
+        const response = await fetch(`/export/${format}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(getReportData())
+        });
+        if (!response.ok) throw new Error('Export failed');
+
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `financial_report.${format}`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+      } catch (e) {
+        alert('⚠ Could not export report. Please try again.');
+      }
+    }
   </script>
   {% block scripts %}{% endblock %}
 </body>

--- a/templates/score.html
+++ b/templates/score.html
@@ -39,7 +39,6 @@
 {% block scripts %}
 <script>
   let scoreChartInstance = null;
-  let lastReportData = null;
 
   async function calcScore() {
     const incomeRaw = document.getElementById('s_income').value;
@@ -113,16 +112,13 @@
           </div>
         `);
 
-        lastReportData = {
+        updateReportData({
           income, expenses, savings,
           investments: invest,
           debt, emergency,
-          money_score: `${data.score} (${data.status})`,
-          tax: 'N/A',
-          sip_projection: 'N/A'
-        };
-        const exportSection = document.getElementById('export-section');
-        if (exportSection) exportSection.style.display = 'flex';
+          money_score: `${data.score} (${data.status})`
+        });
+        showExportSection();
 
         // Compute sub-scores locally for visual rendering
         const savingsRateVal = income>0? parseFloat(savings) / parseFloat(income):0;
@@ -198,33 +194,8 @@
       scoreChartInstance.destroy();
       scoreChartInstance = null;
     }
-    lastReportData = null;
     const exportSection = document.getElementById('export-section');
     if (exportSection) exportSection.style.display = 'none';
-  }
-
-  async function exportReport(format) {
-    if (!lastReportData) return;
-    try {
-      const response = await fetch(`/export/${format}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(lastReportData)
-      });
-      if (!response.ok) throw new Error('Export failed');
-
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `financial_report.${format}`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      window.URL.revokeObjectURL(url);
-    } catch (e) {
-      showResult('scoreResult', '⚠ Could not export report.');
-    }
   }
 </script>
 {% endblock %}

--- a/templates/score.html
+++ b/templates/score.html
@@ -21,6 +21,10 @@
         <button class="btn btn-ghost" style="flex:1" onclick="resetScore()" id="scoreResetBtn">Reset</button>
       </div>
       <div id="scoreResult" class="result-box"></div>
+      <div id="export-section" style="display:none; gap:10px; margin-top:14px;">
+        <button class="btn btn-ghost" style="flex:1" onclick="exportReport('csv')" id="exportCsvBtn">⬇️ Download CSV</button>
+        <button class="btn btn-ghost" style="flex:1" onclick="exportReport('pdf')" id="exportPdfBtn">📄 Download PDF</button>
+      </div>
     </div>
     <div class="card" style="min-height: 380px;">
       <div class="card-title">Financial Health Breakdown</div>
@@ -35,6 +39,7 @@
 {% block scripts %}
 <script>
   let scoreChartInstance = null;
+  let lastReportData = null;
 
   async function calcScore() {
     const incomeRaw = document.getElementById('s_income').value;
@@ -107,6 +112,17 @@
             </div>
           </div>
         `);
+
+        lastReportData = {
+          income, expenses, savings,
+          investments: invest,
+          debt, emergency,
+          money_score: `${data.score} (${data.status})`,
+          tax: 'N/A',
+          sip_projection: 'N/A'
+        };
+        const exportSection = document.getElementById('export-section');
+        if (exportSection) exportSection.style.display = 'flex';
 
         // Compute sub-scores locally for visual rendering
         const savingsRateVal = income>0? parseFloat(savings) / parseFloat(income):0;
@@ -181,6 +197,33 @@
     if (scoreChartInstance) {
       scoreChartInstance.destroy();
       scoreChartInstance = null;
+    }
+    lastReportData = null;
+    const exportSection = document.getElementById('export-section');
+    if (exportSection) exportSection.style.display = 'none';
+  }
+
+  async function exportReport(format) {
+    if (!lastReportData) return;
+    try {
+      const response = await fetch(`/export/${format}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(lastReportData)
+      });
+      if (!response.ok) throw new Error('Export failed');
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `financial_report.${format}`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (e) {
+      showResult('scoreResult', '⚠ Could not export report.');
     }
   }
 </script>

--- a/templates/sip.html
+++ b/templates/sip.html
@@ -25,6 +25,10 @@
       </div>
 
       <div id="sipResult" class="result-box"></div>
+      <div id="export-section" style="display:none; gap:10px; margin-top:14px;">
+        <button class="btn btn-ghost" style="flex:1" onclick="exportReport('csv')" id="exportCsvBtn">⬇️ Download CSV</button>
+        <button class="btn btn-ghost" style="flex:1" onclick="exportReport('pdf')" id="exportPdfBtn">📄 Download PDF</button>
+      </div>
     </div>
 
     <div class="card" style="min-height: 380px;">
@@ -67,10 +71,15 @@
           <div style="font-size:11px;color:var(--muted);margin-bottom:6px;text-transform:uppercase;letter-spacing:0.06em">Estimated Future Value</div>
           <div class="result-big">₹${fmtNum(fv)}</div>
           <div style="font-size:12px;color:var(--muted);margin-top:6px">
-            Invested: ₹${fmtNum(monthly * years * 12)} &nbsp;·&nbsp; 
+            Invested: ₹${fmtNum(monthly * years * 12)} &nbsp;·&nbsp;
             Gains: ₹${fmtNum(fv - monthly * years * 12)}
           </div>
         `);
+
+        updateReportData({
+          sip_projection: `Rs. ${fmtNum(fv)} (Invested: Rs. ${fmtNum(monthly * years * 12)})`
+        });
+        showExportSection();
 
         // Compute compounding points
         const monthlyFloat = parseFloat(monthly);
@@ -158,6 +167,8 @@
       sipChartInstance.destroy();
       sipChartInstance = null;
     }
+    const exportSection = document.getElementById('export-section');
+    if (exportSection) exportSection.style.display = 'none';
   }
 </script>
 {% endblock %}

--- a/templates/tax.html
+++ b/templates/tax.html
@@ -53,6 +53,10 @@
       </div>
 
       <div id="taxResult" class="result-box" style="margin-top:16px;"></div>
+      <div id="export-section" style="display:none; gap:10px; margin-top:14px;">
+        <button class="btn btn-ghost" style="flex:1" onclick="exportReport('csv')" id="exportCsvBtn">⬇️ Download CSV</button>
+        <button class="btn btn-ghost" style="flex:1" onclick="exportReport('pdf')" id="exportPdfBtn">📄 Download PDF</button>
+      </div>
 
     <!-- Right: Outputs -->
     <div class="card" id="taxComparisonCard" style="display:none; min-height: 280px;">
@@ -218,6 +222,11 @@
         </div>
       `);
 
+      updateReportData({
+        tax: `Rs. ${fmtNum(payableB || 0)} (${recommendedB})`
+      });
+      showExportSection();
+
     } catch (e) {
       showResult('taxResult', '⚠ Could not reach server.');
     } finally {
@@ -256,6 +265,9 @@
     const bBox = document.getElementById('scenarioBResult');
     if (aBox) aBox.innerHTML = '';
     if (bBox) bBox.innerHTML = '';
+
+    const exportSection = document.getElementById('export-section');
+    if (exportSection) exportSection.style.display = 'none';
   }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
Closes #282

- Adds `POST /export/csv` and `POST /export/pdf` endpoints that generate a downloadable financial report (income, expenses, savings, investments, debt, emergency fund, tax, money score, SIP projection) from posted JSON, using `.get(key, "N/A")` defaults for any missing fields.
- CSV is built with `csv.DictWriter` + `io.StringIO`; PDF is built with `fpdf2` (added to requirements.txt), stripping characters like ₹/emoji that the core PDF fonts can't encode.
- Adds "⬇️ Download CSV" / "📄 Download PDF" buttons to the Money Score, SIP, and Tax pages.
- Since the app is stateless, results from each page are merged into a single report via a shared `localStorage`-based helper (`updateReportData`/`getReportData`/`exportReport` in `base.html`), so a combined report (all 9 fields) can be exported from any of these pages after visiting the others.

## Additional fix (found while testing)
- `/tax/simulate` was returning `400 {'error': "'best_regime'"}` on every request due to two incorrect result key paths — a pre-existing bug unrelated to #282, but it blocked the Tax Scenario Simulator (and the Tax-page export wiring) entirely. Fixed as a separate commit (`3704e23`).

## Test plan
- [x] `python -m pytest tests/` — 104/104 pass
- [x] `/export/csv` and `/export/pdf` tested with empty body, partial data, special characters/emoji, very large numbers, non-JSON body, and extra unexpected fields
- [x] End-to-end (Playwright, desktop): Score → SIP → Tax flow produces a combined CSV/PDF with all 9 fields populated
- [x] Mobile viewport (390x844): export buttons render and CSV download works with no console errors
