### PR TITLE
chore: pin dependency versions and split dev requirements (#283)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ python -m venv venv
 source venv/bin/activate          # Linux/macOS
 # venv\Scripts\activate           # Windows
 
-# Install dependencies
+# Install production dependencies
 pip install -r requirements.txt
+
+# Install development dependencies (for contributors / running tests)
+pip install -r requirements.txt -r requirements-dev.txt
 
 # Configure environment
 cp .env.example .env
@@ -122,6 +125,8 @@ python app.py
 ---
 
 ## 🧪 Testing
+
+> Make sure you've installed dev dependencies: `pip install -r requirements.txt -r requirements-dev.txt`
 
 ```bash
 pytest                        # Full suite

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# requirements-dev.txt
+# Development and testing dependencies (not needed in production)
+# Install with: pip install -r requirements.txt -r requirements-dev.txt
+pytest==9.0.3
+pytest-cov==7.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
- flask==3.1.3
-#changed the version from 3.1.3 to 3.11.9
+flask==3.1.3
 yfinance==1.4.1
 groq==1.4.0
 pdfplumber==0.11.9
 python-dotenv==1.2.2
-pytest
 flask-sqlalchemy==3.1.1
-apscheduler
+apscheduler==3.11.2


### PR DESCRIPTION
## Summary
Closes #283

- Pins all 7 runtime dependencies in `requirements.txt` to their currently working, tested versions.
- Removes `pytest` from `requirements.txt` (it's a dev tool, not a runtime dep) and adds a new `requirements-dev.txt` with `pytest==9.0.3` and `pytest-cov==7.1.0`.
- Cleans up a stray leading space and a stale/incorrect version comment on the `flask` line.
- Updates the README Quick Start section to show separate production vs. dev install commands, and adds a note in the Testing section about installing dev dependencies.

Note: the issue's sample `requirements.txt` was based on an older version of the file. The current file on `main` already had partial pins and additional packages (`flask-sqlalchemy`, `apscheduler`) and no longer lists `openai`/`langchain`, so this PR pins what's actually present rather than the issue's stale snapshot.

## Test plan
- [x] `python -c "import app"` — boots cleanly with pinned versions
- [x] `pip install -r requirements.txt -r requirements-dev.txt` then `pytest` — 104/104 pass