### PR TITLE
fix: prevent sidebar navigation overlap on desktop view

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -117,6 +117,8 @@
     .sidebar {
       width: 220px;
       min-height: 100vh;
+      height: 100vh;
+      overflow-y: auto;
       background: linear-gradient(180deg, rgba(10, 15, 28, 0.95), rgba(15, 23, 40, 0.95));
       border-right: 1px solid rgba(255, 255, 255, 0.08);
       padding: 24px 18px;
@@ -129,6 +131,10 @@
       box-shadow: 2px 0 30px rgba(0, 0, 0, 0.18);
       -ms-overflow-style: none;  /* IE and Edge */
       scrollbar-width: none;  /* Firefox */
+    }
+
+    .sidebar>* {
+      flex-shrink: 0;
     }
 
     .sidebar::-webkit-scrollbar {
@@ -152,6 +158,7 @@
       gap: 10px;
       padding: 10px 12px;
       min-height: 44px;
+      flex-shrink: 0;
       border-radius: 8px;
       cursor: pointer;
       color: var(--muted);


### PR DESCRIPTION
Fixes #296

Changes:
- Set sidebar height to 100vh
- Added sidebar scrolling support
- Prevented navigation items from shrinking and overlapping