### PR TITLE
fix: resolve dependency conflicts and startup crash (Closes #345)

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,8 @@ from flask_login import (
     login_required
 )
 
+from flask_mail import Mail, Message
+
 from werkzeug.security import (
     generate_password_hash,
     check_password_hash
@@ -41,9 +43,6 @@ if not GROQ_API_KEY or GROQ_API_KEY.strip() in ("", "your_groq_api_key_here"):
         "  Obtain a free key at: https://console.groq.com/\n",
         file=sys.stderr,
     )
-
-    sys.exit(1)
-
     client = None
 else:
     client = Groq(api_key=GROQ_API_KEY)

--- a/models.py
+++ b/models.py
@@ -288,61 +288,6 @@ class FinancialGoal(db.Model):
         }
 
 
-# class RecurringExpense(db.Model):
-#     __tablename__ = "recurring_expenses"
-
-<<<<<<< HEAD
-#     id = db.Column(db.Integer, primary_key=True)
-#     category = db.Column(db.String(120), nullable=False)
-#     amount = db.Column(db.Float, nullable=False)
-=======
-    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
-    user = db.relationship("User", backref="recurring_expenses")
-    id = db.Column(db.Integer, primary_key=True)
-    category = db.Column(db.String(120), nullable=False)
-    amount = db.Column(db.Float, nullable=False)
->>>>>>> upstream/main
-
-#     # Stored as YYYY-MM-DD (strings) to keep the model consistent with existing Expense.date usage
-#     start_date = db.Column(db.String(40), nullable=False)
-
-#     frequency = db.Column(db.String(20), nullable=False)  # monthly|weekly|yearly
-#     active = db.Column(db.Boolean, default=True)
-
-#     # Optional end date (YYYY-MM-DD)
-#     end_date = db.Column(db.String(40), nullable=True)
-
-#     created_at = db.Column(db.DateTime, default=datetime.utcnow)
-#     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
-
-<<<<<<< HEAD
-#     def to_dict(self):
-#         return {
-#             "id": self.id,
-#             "category": self.category,
-#             "amount": self.amount,
-#             "start_date": self.start_date,
-#             "frequency": self.frequency,
-#             "active": self.active,
-#             "end_date": self.end_date,
-#             "created_at": self.created_at.isoformat() if self.created_at else None,
-#             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
-#         }
-=======
-    def to_dict(self):
-        return {
-            "id": self.id,
-            "user_id": self.user_id,
-            "category": self.category,
-            "amount": self.amount,
-            "start_date": self.start_date,
-            "frequency": self.frequency,
-            "active": self.active,
-            "end_date": self.end_date,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
-        }
->>>>>>> upstream/main
 
 # ---------------- WEEKLY DIGEST (Scheduled AI) ----------------
 class DigestPreference(db.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 flask==3.1.3
 yfinance==1.4.1
-groq==1.4.0
+groq==1.0.0
 pdfplumber==0.11.9
-python-dotenv==1.2.2
+python-dotenv==1.2.1
 flask-sqlalchemy==3.1.1
 apscheduler==3.11.2
 fpdf2==2.8.7
 flask-login
 werkzeug
+flask-mail==0.10.0


### PR DESCRIPTION
Closes #345

## Summary
Started investigating the original syntax/dependency error and found
the scope grew from 2 to 5 issues once I traced the dependency chain
and tested startup without a GROQ_API_KEY set.

## Changes

1. **requirements.txt** — Fixed broken/non-existent pins:
   - `groq==1.4.0` → `groq==1.0.0`
   - `python-dotenv==1.2.2` → `python-dotenv==1.2.1`
   - Added missing `flask-mail==0.10.0` (imported in app.py but not declared)

2. **app.py** — Added missing `from flask_mail import Mail, Message`
   import, and removed a `sys.exit(1)` that killed the app whenever
   `GROQ_API_KEY` was unset — even though the very next log line says
   the app will run in offline mode. The exit was contradicting its
   own intended behavior.

3. **models.py** — Removed a dead, fully-commented-out duplicate
   `RecurringExpense` class (lines 291–345) left over from an
   unresolved merge — it still contained literal `<<<<<<< HEAD` /
   `=======` / `>>>>>>> upstream/main` conflict markers. The real,
   active `RecurringExpense` class (line 14) is untouched.

## Testing
- Verified `python app.py` starts cleanly with no `GROQ_API_KEY` set,
  dashboard loads at `http://127.0.0.1:5000`
- Ran full test suite: 104 passed, 10 failed
  - All 10 failures are **pre-existing**, not introduced by this PR:
    - `test_portfolio.py::test_portfolio_page_render` — separate
      `base.html` template bug (`block 'title' defined twice`),
      will file as its own issue
    - `test_budget.py` (3), `test_expense_crud.py` (1),
      `test_validation.py::test_add_expense_endpoint` (1) — unrelated
      to files touched in this PR
    - `test_chat_context.py` (3), `test_offline_fallback.py` (1) —
      confirmed not caused by the groq version pin (reproduced
      identically on both `groq==1.0.0` and `groq==1.4.0`); these
      paths were previously unreachable because the app crashed on
      import before offline mode could ever run, so this PR is what
      first exposes them