### PR TITLE
fix: surface errors in loadBudgetStatus and loadAlertsFeed

### DIFF
--- a/templates/budget.html
+++ b/templates/budget.html
@@ -180,8 +180,10 @@
       }
       
     } catch (err) {
-      console.error(err);
-    }
+    console.error(err);
+    document.getElementById("budgetAdvice").innerHTML = 
+      "⚠️ Could not load budget data. Please refresh the page.";
+  }
   }
 
   async function loadAlertsFeed() {
@@ -210,8 +212,12 @@
         `;
       });
     } catch (err) {
-      console.error(err);
-    }
+    console.error(err);
+    document.getElementById("alertsFeed").innerHTML = 
+      `<div style="text-align:center; padding:20px; color:var(--red); font-style:italic;">
+        ⚠️ Could not load alerts. Please refresh the page.
+      </div>`;
+  }
   }
 
   async function triggerManualChecks() {


### PR DESCRIPTION

## Problem

Both functions caught errors but only logged them to the console. 
If the `/budget/status` or `/budget/alerts` request failed, the 
page was left showing stale or placeholder content with no 
indication that something went wrong.



## What changed

Added a visible error message inside the relevant container when 
the fetch request fails, while still keeping the console error log 
for developers.



## Before

```js
async function loadBudgetStatus() {
  try {
    // ... fetch and render budget data ...
  } catch (err) {
    console.error(err);
  }
}

async function loadAlertsFeed() {
  try {
    // ... fetch and render alerts ...
  } catch (err) {
    console.error(err);
  }
}
```



## After

```js
async function loadBudgetStatus() {
  try {
    // ... fetch and render budget data ...
  } catch (err) {
    console.error(err);
    document.getElementById("budgetAdvice").innerHTML = 
      "⚠️ Could not load budget data. Please refresh the page.";
  }
}

async function loadAlertsFeed() {
  try {
    // ... fetch and render alerts ...
  } catch (err) {
    console.error(err);
    document.getElementById("alertsFeed").innerHTML = 
      `<div style="text-align:center; padding:20px; color:var(--red); font-style:italic;">
        ⚠️ Could not load alerts. Please refresh the page.
      </div>`;
  }
}
```



## Why it matters

- User now knows immediately if data failed to load, instead of 
  seeing misleading stale content
- No need to open dev tools to understand something went wrong
- Console error logging is still kept for developers


## Testing

- Simulated a failed `/budget/status` request → error message shown correctly
- Simulated a failed `/budget/alerts` request → error message shown correctly
- Normal successful loads still work as before



## Files changed

- `budget.html`



Closes #356