### PR TITLE
 trim chat history before saving to prevent localStorage quota errors

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -41,7 +41,8 @@ list_recurring_expenses
   // ─── localStorage helpers ─────────────────────────────────────────────────
   function saveHistory() {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(chatHistory));
+       const trimmed = chatHistory.slice(-50);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
     } catch (e) {
       console.warn('Could not save chat history to localStorage:', e);
     }


### PR DESCRIPTION

## Problem

`chatHistory` grows unbounded as the conversation continues — there 
was no trimming or size limit. Every message was saved to 
`localStorage`, which has a hard quota (typically ~5-10MB depending 
on browser). Once the quota was hit, saving failed silently with 
only a `console.warn`, giving the user no visible feedback.


## What changed

Added trimming logic in `saveHistory()` so only the most recent 50 
messages are kept before saving to `localStorage`. This prevents 
the history from ever growing large enough to hit the quota limit.



## Before

```js
function saveHistory() {
  try {
    localStorage.setItem(STORAGE_KEY, JSON.stringify(chatHistory));
  } catch (e) {
    console.warn('Could not save chat history to localStorage:', e);
  }
}
```



## After

```js
function saveHistory() {
  try {
    const trimmed = chatHistory.slice(-50);
    localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
  } catch (e) {
    console.warn('Could not save chat history to localStorage:', e);
  }
}
```



## Why it matters

- Chat history no longer silently fails to save during long conversations
- Storage stays well within the localStorage quota limit
- Console warning is still kept for developers in case of any other failure


## Testing

- Sent many messages in a long conversation → history saved correctly 
  without hitting quota
- Refreshed the page → most recent 50 messages loaded correctly
- Cleared chat → history reset as expected



## Files changed

- `chat.html`


Closes #355