### PR TITLE
feat: add step-up SIP calculator

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,7 +65,7 @@ else:
     client = Groq(api_key=GROQ_API_KEY)
 
 # ---------------- IMPORT UTILS ----------------
-from utils.sip import calculate_sip, calculate_goal_sip
+from utils.sip import calculate_sip, calculate_goal_sip, calculate_stepup_sip
 from utils.tax import calculate_tax, tax_optimization_module
 from utils.pdf_parser import extract_income
 from utils.money_score import calculate_money_score
@@ -1754,6 +1754,29 @@ def sip():
             "inflation_applied": result["inflation_applied"],
             "explainability": explainability
         })
+
+    except ValidationError as e:
+        raise e
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+    
+@app.route("/sip-stepup", methods=["POST"])
+def sip_stepup():
+    try:
+        data = request.json or {}
+        if not isinstance(data, dict):
+            raise ValidationError("Request body must be a JSON object")
+        monthly = validate_float(data.get("monthly"), "monthly", min_val=0.0)
+        rate = validate_float(data.get("rate"), "rate", min_val=0.0)
+        years = validate_int(data.get("years"), "years", min_val=1)
+        stepup_type = validate_string(data.get("stepup_type"), "stepup_type")
+        if stepup_type not in ("percentage", "amount"):
+            raise ValidationError("'stepup_type' must be 'percentage' or 'amount'")
+        stepup_value = validate_float(data.get("stepup_value"), "stepup_value", min_val=0.0)
+        inflation = validate_float(data.get("inflation", 0.0), "inflation", min_val=0.0)
+
+        result = calculate_stepup_sip(monthly, rate, years, stepup_type, stepup_value, inflation)
+        return jsonify(result)
 
     except ValidationError as e:
         raise e

--- a/templates/sip.html
+++ b/templates/sip.html
@@ -42,6 +42,7 @@
     </div>
   </div>
 
+
   <!-- SIP Explainability & What-If Simulation -->
   <div id="sip-explainability" class="card" style="display: none; max-width: 900px; margin-top: 20px;">
     <div class="card-title">💡 Explainable Projections & Sensitivity Analysis</div>
@@ -109,6 +110,30 @@
             <div style="font-size:11px; color:var(--muted)">Adjusted purchasing power increases by the above amount.</div>
           </div>
         </div>
+
+<!-- ── STEP-UP SIP ─────────────────── -->
+  <div style="display:flex;flex-wrap:wrap;gap:20px;align-items:start;max-width:900px;margin-top:4px;">
+    <div class="card" style="flex:1;min-width:280px;">
+      <div class="card-title">📈 Step-Up SIP</div>
+      <div style="font-size:13px;color:var(--muted);margin-bottom:14px;">Uses Monthly, Rate &amp; Years from SIP Projection above.</div>
+      <label>Step-Up Type</label>
+      <div style="display:flex;gap:10px;margin-bottom:14px;">
+        <button id="stepupTypePerc" class="btn btn-gold" style="flex:1" onclick="setStepupType('percentage')">% Annual</button>
+        <button id="stepupTypeAmt" class="btn btn-ghost" style="flex:1" onclick="setStepupType('amount')">₹ Annual</button>
+      </div>
+      <label id="stepupValueLabel">Annual Step-Up (%)</label>
+      <input type="number" min="0" id="stepup_value" placeholder="e.g. 10">
+      <label>Inflation Rate (%) <span style="font-size:11px;color:var(--muted)">(optional)</span></label>
+      <input type="number" min="0" id="stepup_inflation" placeholder="e.g. 6">
+      <button class="btn btn-gold" style="margin-top:16px;width:100%" onclick="calcStepupSIP()" id="stepupBtn">
+        Compare with Step-Up
+      </button>
+      <div id="stepupResult" class="result-box"></div>
+    </div>
+    <div class="card" style="min-height:380px;flex:1.2;min-width:280px;">
+      <div class="card-title">Flat vs Step-Up Comparison</div>
+      <div style="position:relative;height:320px;">
+        <canvas id="stepupChart"></canvas>
       </div>
     </div>
   </div>
@@ -281,6 +306,138 @@
     setLoading('sipBtn', false);
   }
 
+  let stepupChartInstance = null;
+  let currentStepupType = 'percentage';
+
+  function setStepupType(type) {
+    currentStepupType = type;
+    document.getElementById('stepupValueLabel').textContent =
+      type === 'percentage' ? 'Annual Step-Up (%)' : 'Annual Step-Up (₹)';
+    document.getElementById('stepup_value').placeholder =
+      type === 'percentage' ? 'e.g. 10' : 'e.g. 1000';
+    document.getElementById('stepupTypePerc').className =
+      type === 'percentage' ? 'btn btn-gold' : 'btn btn-ghost';
+    document.getElementById('stepupTypeAmt').className =
+      type === 'amount' ? 'btn btn-gold' : 'btn btn-ghost';
+  }
+
+  async function calcStepupSIP() {
+    const monthly = document.getElementById('sip_monthly').value;
+    const rate = document.getElementById('sip_rate').value;
+    const years = document.getElementById('sip_years').value;
+    const stepup_value = document.getElementById('stepup_value').value;
+    const inflation = document.getElementById('stepup_inflation').value;
+
+    if (!monthly || !rate || !years) {
+      showResult('stepupResult', '⚠ Please fill Monthly Investment, Rate and Years in SIP Projection above first.');
+      return;
+    }
+    if (stepup_value === '') {
+      showResult('stepupResult', '⚠ Please enter a Step-Up value.');
+      return;
+    }
+
+    setLoading('stepupBtn', true);
+    try {
+      const data = await apiFetch('/sip-stepup', {
+        monthly: parseFloat(monthly),
+        rate: parseFloat(rate),
+        years: parseInt(years),
+        stepup_type: currentStepupType,
+        stepup_value: parseFloat(stepup_value),
+        inflation: inflation ? parseFloat(inflation) : 0.0
+      });
+
+      if (data.error) {
+        showResult('stepupResult', `⚠ ${data.error}`);
+      } else {
+        const fvFlat = data.flat_nominal_value;
+        const fvStepup = data.stepup_nominal_value;
+        const gain = fvStepup - fvFlat;
+        showResult('stepupResult', `
+          <div style="display:flex;gap:16px;flex-wrap:wrap;margin-bottom:8px;">
+            <div style="flex:1;min-width:120px;">
+              <div style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em;">Flat SIP</div>
+              <div class="result-big" style="font-size:20px;">₹${fmtNum(fvFlat)}</div>
+              <div style="font-size:11px;color:var(--muted);">Invested: ₹${fmtNum(data.flat_total_invested)}</div>
+            </div>
+            <div style="flex:1;min-width:120px;">
+              <div style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em;">Step-Up SIP</div>
+              <div class="result-big" style="font-size:20px;color:#14c8bf;">₹${fmtNum(fvStepup)}</div>
+              <div style="font-size:11px;color:var(--muted);">Invested: ₹${fmtNum(data.stepup_total_invested)}</div>
+            </div>
+          </div>
+          <div style="font-size:12px;color:var(--muted);">
+            Extra wealth from step-up: <strong style="color:#14c8bf;">₹${fmtNum(gain)}</strong>
+          </div>
+        `);
+
+        const labels = data.yearly_breakdown.map(y => `Year ${y.year}`);
+        const flatData = data.yearly_breakdown.map(y => Math.round(y.flat_value));
+        const stepupData = data.yearly_breakdown.map(y => Math.round(y.stepup_value));
+        const investedData = data.yearly_breakdown.map(y => Math.round(y.flat_invested));
+
+        if (stepupChartInstance) stepupChartInstance.destroy();
+        const ctx = document.getElementById('stepupChart').getContext('2d');
+        stepupChartInstance = new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: 'Step-Up SIP',
+                data: stepupData,
+                borderColor: '#14c8bf',
+                backgroundColor: 'rgba(20, 200, 191, 0.1)',
+                fill: true,
+                tension: 0.3
+              },
+              {
+                label: 'Flat SIP',
+                data: flatData,
+                borderColor: '#d4a843',
+                backgroundColor: 'rgba(212, 168, 67, 0.08)',
+                fill: true,
+                tension: 0.3
+              },
+              {
+                label: 'Amount Invested',
+                data: investedData,
+                borderColor: '#5a6a82',
+                backgroundColor: 'transparent',
+                borderDash: [5, 5],
+                tension: 0.1
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { labels: { color: '#eef0f5', font: { family: 'Instrument Sans' } } }
+            },
+            scales: {
+              x: {
+                grid: { color: 'rgba(255,255,255,0.05)' },
+                ticks: { color: '#5a6a82' }
+              },
+              y: {
+                grid: { color: 'rgba(255,255,255,0.05)' },
+                ticks: {
+                  color: '#5a6a82',
+                  callback: function(value) { return '₹' + fmtNum(value); }
+                }
+              }
+            }
+          }
+        });
+      }
+    } catch (e) {
+      showResult('stepupResult', '⚠ Could not reach server.');
+    }
+    setLoading('stepupBtn', false);
+  }
+  
   function resetSIP() {
     document.getElementById('sip_monthly').value = '';
     document.getElementById('sip_rate').value = '';

--- a/tests/test_sip.py
+++ b/tests/test_sip.py
@@ -8,7 +8,7 @@ Run with:  pytest tests/test_sip.py -v
 """
 
 import pytest
-from utils.sip import calculate_sip
+from utils.sip import calculate_sip, calculate_stepup_sip
 
 
 class TestCalculateSip:
@@ -68,3 +68,113 @@ class TestCalculateSip:
         expected_discount = result["nominal_value"] / ((1 + m) ** 60)
         assert abs(result["inflation_adjusted_value"] - expected_discount) < 1.0
 
+
+class TestCalculateStepupSip:
+
+    def test_matches_flat_sip_when_stepup_value_is_zero_percentage(self):
+        """A 0% step-up should produce identical numbers to a flat SIP."""
+        result = calculate_stepup_sip(
+            monthly=5000, rate=12, years=5,
+            stepup_type="percentage", stepup_value=0
+        )
+        flat = calculate_sip(monthly=5000, rate=12, years=5)
+        assert result["stepup_nominal_value"] == result["flat_nominal_value"]
+        assert result["flat_nominal_value"] == flat["nominal_value"]
+
+    def test_matches_flat_sip_when_stepup_value_is_zero_amount(self):
+        """A Rs 0 step-up should also produce identical numbers to flat SIP."""
+        result = calculate_stepup_sip(
+            monthly=5000, rate=12, years=5,
+            stepup_type="amount", stepup_value=0
+        )
+        assert result["stepup_nominal_value"] == result["flat_nominal_value"]
+
+    def test_flat_value_matches_existing_calculate_sip(self):
+        """The flat-SIP branch of this function must agree with calculate_sip
+        exactly, since the frontend chart plots both lines and they must be
+        consistent with the standalone /sip endpoint."""
+        result = calculate_stepup_sip(
+            monthly=10000, rate=10, years=10,
+            stepup_type="percentage", stepup_value=10
+        )
+        flat = calculate_sip(monthly=10000, rate=10, years=10)
+        assert result["flat_nominal_value"] == flat["nominal_value"]
+
+    def test_percentage_stepup_grows_more_than_flat(self):
+        result = calculate_stepup_sip(
+            monthly=5000, rate=12, years=10,
+            stepup_type="percentage", stepup_value=10
+        )
+        assert result["stepup_nominal_value"] > result["flat_nominal_value"]
+        assert result["stepup_total_invested"] > result["flat_total_invested"]
+
+    def test_amount_stepup_grows_more_than_flat(self):
+        result = calculate_stepup_sip(
+            monthly=5000, rate=12, years=10,
+            stepup_type="amount", stepup_value=1000
+        )
+        assert result["stepup_nominal_value"] > result["flat_nominal_value"]
+
+    def test_invalid_stepup_type_raises(self):
+        with pytest.raises(ValueError):
+            calculate_stepup_sip(
+                monthly=5000, rate=12, years=5,
+                stepup_type="bogus", stepup_value=10
+            )
+
+    def test_single_year_stepup_equals_flat(self):
+        """With only 1 year, the step-up never triggers (it only applies
+        after month 12), so step-up and flat results must be identical."""
+        result = calculate_stepup_sip(
+            monthly=5000, rate=12, years=1,
+            stepup_type="percentage", stepup_value=15
+        )
+        assert result["stepup_nominal_value"] == result["flat_nominal_value"]
+
+    def test_zero_rate_with_stepup(self):
+        """rate=0 must not divide by zero, and step-up still increases
+        total invested even with no growth."""
+        result = calculate_stepup_sip(
+            monthly=5000, rate=0, years=3,
+            stepup_type="amount", stepup_value=500
+        )
+        assert result["stepup_nominal_value"] == result["stepup_total_invested"]
+        assert result["stepup_total_invested"] > result["flat_total_invested"]
+
+    def test_yearly_breakdown_length_matches_years(self):
+        result = calculate_stepup_sip(
+            monthly=5000, rate=12, years=7,
+            stepup_type="percentage", stepup_value=10
+        )
+        assert len(result["yearly_breakdown"]) == 7
+        assert result["yearly_breakdown"][0]["year"] == 1
+        assert result["yearly_breakdown"][-1]["year"] == 7
+
+    def test_yearly_breakdown_values_are_monotonically_increasing(self):
+        result = calculate_stepup_sip(
+            monthly=5000, rate=12, years=5,
+            stepup_type="percentage", stepup_value=10
+        )
+        values = [y["stepup_value"] for y in result["yearly_breakdown"]]
+        assert values == sorted(values)
+        invested = [y["stepup_invested"] for y in result["yearly_breakdown"]]
+        assert invested == sorted(invested)
+
+    def test_inflation_adjustment_applied(self):
+        result = calculate_stepup_sip(
+            monthly=5000, rate=12, years=10,
+            stepup_type="percentage", stepup_value=10,
+            inflation_rate=6
+        )
+        assert result["inflation_applied"] == 6
+        assert result["stepup_inflation_adjusted_value"] < result["stepup_nominal_value"]
+        assert result["flat_inflation_adjusted_value"] < result["flat_nominal_value"]
+
+    def test_no_inflation_means_adjusted_equals_nominal(self):
+        result = calculate_stepup_sip(
+            monthly=5000, rate=12, years=5,
+            stepup_type="amount", stepup_value=500
+        )
+        assert result["inflation_applied"] == 0.0
+        assert result["stepup_inflation_adjusted_value"] == result["stepup_nominal_value"]
+        assert result["flat_inflation_adjusted_value"] == result["flat_nominal_value"]

--- a/utils/sip.py
+++ b/utils/sip.py
@@ -28,7 +28,7 @@ def calculate_sip(monthly, rate, years, inflation_rate=0.0):
     else:
         r = rate / 100 / 12
         fv = monthly * (((1 + r)**n - 1) / r) * (1 + r)
-    
+
     if inflation_rate > 0:
         m = inflation_rate / 100 / 12
         fv_adjusted = fv / ((1 + m) ** n)
@@ -37,10 +37,88 @@ def calculate_sip(monthly, rate, years, inflation_rate=0.0):
             "inflation_adjusted_value": round(fv_adjusted, 2),
             "inflation_applied": inflation_rate
         }
-        
+
     return {
         "nominal_value": round(fv, 2),
         "inflation_adjusted_value": round(fv, 2),
         "inflation_applied": 0.0
     }
 
+
+def calculate_stepup_sip(monthly, rate, years, stepup_type, stepup_value, inflation_rate=0.0):
+    """Simulate a step-up SIP and compare it against a flat SIP.
+
+    The monthly contribution increases once every 12 months by either
+    a percentage or a fixed rupee amount, compounding monthly at the
+    given annual rate (annuity-due convention, matching calculate_sip).
+    Returns nominal totals plus a year-by-year breakdown so the
+    frontend can chart step-up growth against flat growth.
+
+    Args:
+        monthly: Starting monthly SIP amount.
+        rate: Expected annual return rate (%).
+        years: Investment duration in years.
+        stepup_type: "percentage" or "amount".
+        stepup_value: Annual increase, e.g. 10 for 10%, or 1000 for Rs 1,000.
+        inflation_rate: Optional annual inflation rate (%) for adjusted value.
+    """
+    if stepup_type not in ("percentage", "amount"):
+        raise ValueError("stepup_type must be 'percentage' or 'amount'")
+
+    n = years * 12
+    r = rate / 100 / 12
+
+    def _simulate(apply_stepup):
+        current = monthly
+        corpus = 0.0
+        invested = 0.0
+        yearly = []
+        for month in range(1, n + 1):
+            if apply_stepup and month > 1 and (month - 1) % 12 == 0:
+                if stepup_type == "percentage":
+                    current = current * (1 + stepup_value / 100)
+                else:
+                    current = current + stepup_value
+            corpus = (corpus + current) * (1 + r)
+            invested += current
+            if month % 12 == 0:
+                yearly.append({
+                    "year": month // 12,
+                    "invested": round(invested, 2),
+                    "value": round(corpus, 2)
+                })
+        return corpus, invested, yearly
+
+    stepup_corpus, stepup_invested, stepup_yearly = _simulate(True)
+    flat_corpus, flat_invested, flat_yearly = _simulate(False)
+
+    yearly_breakdown = [
+        {
+            "year": s["year"],
+            "flat_value": f["value"],
+            "stepup_value": s["value"],
+            "flat_invested": f["invested"],
+            "stepup_invested": s["invested"]
+        }
+        for s, f in zip(stepup_yearly, flat_yearly)
+    ]
+
+    result = {
+        "stepup_nominal_value": round(stepup_corpus, 2),
+        "stepup_total_invested": round(stepup_invested, 2),
+        "flat_nominal_value": round(flat_corpus, 2),
+        "flat_total_invested": round(flat_invested, 2),
+        "yearly_breakdown": yearly_breakdown,
+        "inflation_applied": 0.0
+    }
+
+    if inflation_rate > 0:
+        m = inflation_rate / 100 / 12
+        result["stepup_inflation_adjusted_value"] = round(stepup_corpus / ((1 + m) ** n), 2)
+        result["flat_inflation_adjusted_value"] = round(flat_corpus / ((1 + m) ** n), 2)
+        result["inflation_applied"] = inflation_rate
+    else:
+        result["stepup_inflation_adjusted_value"] = result["stepup_nominal_value"]
+        result["flat_inflation_adjusted_value"] = result["flat_nominal_value"]
+
+    return result


### PR DESCRIPTION
Closes #315

## Changes
- `utils/sip.py`: Added `calculate_stepup_sip()` — simulates month-by-month compounding with annual % or ₹ step-up, returns flat vs step-up totals and yearly breakdown for charting
- `tests/test_sip.py`: Added 12 tests for `calculate_stepup_sip` (22/22 passing total)
- `app.py`: Added `/sip-stepup` POST route with full input validation
- `templates/sip.html`: Added Step-Up SIP card with % / ₹ toggle, inflation input, and flat vs step-up comparison chart

## Testing
- All 22 SIP tests pass
- Full test suite: 116 passed, 10 failed — all 10 failures are pre-existing (confirmed on clean main before this branch)
- API endpoint verified manually: `/sip-stepup` returns correct flat and step-up corpus values