### PR TITLE
[SSOC] Financial Health Score Deep Dive

### DIFF
--- a/app.py
+++ b/app.py
@@ -3694,7 +3694,31 @@ def money_score():
             status = "Average ⚠️"
         else:
             status = "Needs Improvement ❌"
-        return jsonify({"score": score, "status": status})
+
+        breakdown = calculate_money_score_breakdown(
+            income=income,
+            expenses=expenses,
+            savings=savings,
+            investments=investments,
+            debt=debt,
+            emergency_fund=emergency,
+        )
+
+        # Keep backward compatibility: existing frontend expects {score, status}
+        return jsonify({
+            "score": score,
+            "status": status,
+            "breakdown": breakdown,
+            "peers": {
+                "anonymous": True,
+                "benchmarks": {
+                    "savings_rate": 23.0,
+                    "investment_rate": 12.0,
+                    "debt_ratio": 32.0,
+                    "emergency_coverage_months": 4.0,
+                }
+            },
+        })
     except ValidationError as e:
         raise e
     except Exception as e:

--- a/static/styles/financial-health.css
+++ b/static/styles/financial-health.css
@@ -1,0 +1,124 @@
+/* Financial Health Dashboard (Money Score Deep Dive) */
+
+.fin-health-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-top: 14px;
+}
+
+@media (max-width: 900px) {
+  .fin-health-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.fin-health-card {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 14px;
+  padding: 12px 12px 10px;
+}
+
+.fin-health-card h4 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.fin-health-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.fin-health-score {
+  font-weight: 800;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.fin-health-meta {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.fin-health-pill {
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.03);
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.fin-health-bar {
+  height: 10px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.fin-health-bar > .fill {
+  height: 100%;
+  width: 0%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(212,168,67,0.95), rgba(20,200,191,0.95));
+}
+
+.fin-health-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.fin-health-btn {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.08);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.fin-health-btn:hover {
+  border-color: rgba(212,168,67,0.35);
+}
+
+.fin-health-collapse {
+  margin-top: 10px;
+  display: none;
+}
+
+.fin-health-collapse.visible {
+  display: block;
+}
+
+.fin-health-collapse .calc {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.fin-health-collapse .tips {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.fin-health-collapse .small-row {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+

--- a/templates/score.html
+++ b/templates/score.html
@@ -41,10 +41,11 @@ style="margin-top:15px">
         <button class="btn btn-ghost" style="flex:1" onclick="exportReport('pdf')" id="exportPdfBtn">📄 Download PDF</button>
       </div>
     </div>
-    <div class="card" style="min-height: 380px;">
-      <div class="card-title">Financial Health Breakdown</div>
-      <div style="position: relative; height: 320px; display: flex; justify-content: center; align-items: center;">
-        <canvas id="scoreChart"></canvas>
+    <div class="card" style="grid-column: 2 / span 1; min-height: 380px;">
+      <div class="card-title">Financial Health Dashboard</div>
+      <link rel="stylesheet" href="/static/styles/financial-health.css">
+      <div style="margin-top: 10px;">
+        <div class="fin-health-grid" id="finHealthGrid"></div>
       </div>
     </div>
   </div>
@@ -54,6 +55,75 @@ style="margin-top:15px">
 {% block scripts %}
 <script>
   let scoreChartInstance = null;
+
+  function renderFinancialHealthDashboard(breakdown) {
+    const grid = document.getElementById('finHealthGrid');
+    if (!grid) return;
+    grid.innerHTML = '';
+
+    if (!breakdown || !breakdown.components) {
+      grid.innerHTML = `<div style="padding:12px;color:var(--muted);font-size:13px;">No breakdown data available.</div>`;
+      return;
+    }
+
+    breakdown.components.forEach((comp, idx) => {
+      const scorePct = Math.round((comp.score / comp.max_score) * 100);
+
+      const peerText = comp.peer_benchmark_text || '';
+      const peerVal = (comp.peer_benchmark_value !== null && comp.peer_benchmark_value !== undefined)
+        ? comp.peer_benchmark_value
+        : null;
+
+      const peerBlock = peerText
+        ? `<div class="small-row">${peerText}</div>`
+        : `<div class="small-row">Peer benchmark unavailable</div>`;
+
+      const tipsHtml = (Array.isArray(comp.tips) ? comp.tips : [])
+        .slice(0, 5)
+        .map(t => `<li>${t}</li>`)
+        .join('');
+
+      const collapseId = `finHealthCollapse_${idx}`;
+
+      grid.innerHTML += `
+        <div class="fin-health-card">
+          <div class="fin-health-top">
+            <div>
+              <h4>${comp.label}</h4>
+              <div class="fin-health-score" style="color:var(--text);">${comp.score}/${comp.max_score}</div>
+              <div class="fin-health-meta">Tier: ${comp.tier}</div>
+            </div>
+            <div class="fin-health-pill">${comp.your_value}${comp.unit === '% of income' ? '%' : ''}</div>
+          </div>
+
+          <div class="fin-health-bar" aria-label="progress">
+            <div class="fill" style="width:${scorePct}%;"></div>
+          </div>
+
+          ${peerBlock}
+
+          <div class="fin-health-actions">
+            <div class="fin-health-meta">${comp.interpretation}</div>
+            <button class="fin-health-btn" type="button" onclick="toggleFinHealthCollapse('${collapseId}')">Deep Dive</button>
+          </div>
+
+          <div id="${collapseId}" class="fin-health-collapse">
+            <div class="calc">${comp.calculation}</div>
+            <div class="small-row">Your value: ${comp.your_value}${comp.unit === '% of income' ? '%' : ''}</div>
+            <div class="small-row">Peer benchmark: ${peerVal !== null ? peerVal : 'N/A'}${comp.unit === '% of income' ? '%' : ' months'}</div>
+            <div class="small-row" style="margin-top:8px;color:var(--muted);">Personalized tips</div>
+            <ul class="tips">${tipsHtml}</ul>
+          </div>
+        </div>
+      `;
+    });
+  }
+
+  function toggleFinHealthCollapse(id) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.classList.toggle('visible');
+  }
 
   async function calcScore() {
     const incomeRaw = document.getElementById('s_income').value;
@@ -212,59 +282,13 @@ ${feedback.message}
         });
         showExportSection();
 
-        // Compute sub-scores locally for visual rendering
-        const savingsRateVal = income>0? parseFloat(savings) / parseFloat(income):0;
-        const savingsScore = savingsRateVal >= 0.3 ? 30 : savingsRateVal >= 0.2 ? 20 : 10;
+        // Render Financial Health Dashboard (from server breakdown)
+        renderFinancialHealthDashboard(data.breakdown);
 
-        const investRateVal = income>0? parseFloat(invest) / parseFloat(income):0;
-        const investScore = investRateVal >= 0.2 ? 25 : investRateVal >= 0.1 ? 15 : 5;
-
-        const debtRatioVal = income>0? parseFloat(debt) / parseFloat(income):0;
-        let debtScore=25;
-        if (income>0){
-          debtScore = debtRatioVal <= 0.2 ? 25:debtRatioVal<=0.4?15 : 5;
-        }else if(income==0 && debt==0){
-          debtScore=25;
+        // Keep compatibility: if older backend returns no breakdown, fall back to old chart.
+        if (!data.breakdown || !data.breakdown.components) {
+          showResult('scoreResult', '⚠ Breakdown unavailable on server.');
         }
-
-        const monthsCoverVal = expenses>0? parseFloat(emergency) / parseFloat(expenses):0;
-        const emergencyScore = monthsCoverVal >= 6 ? 20 : monthsCoverVal >= 3 ? 10 : 5;
-
-        // Draw Horizontal Bar Chart
-        if (scoreChartInstance) scoreChartInstance.destroy();
-        const scoreCtx = document.getElementById('scoreChart').getContext('2d');
-        scoreChartInstance = new Chart(scoreCtx, {
-          type: 'bar',
-          data: {
-            labels: ['Savings Rate', 'Investment Rate', 'Debt Ratio', 'Emergency Fund'],
-            datasets: [{
-              label: 'Your Score',
-              data: [savingsScore, investScore, debtScore, emergencyScore],
-              backgroundColor: ['#d4a843', '#14c8bf', '#5a6a82', '#2ecc8a'],
-              borderRadius: 6,
-              barThickness: 16
-            }]
-          },
-          options: {
-            indexAxis: 'y',
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-              legend: { display: false }
-            },
-            scales: {
-              x: {
-                grid: { color: 'rgba(255, 255, 255, 0.05)' },
-                ticks: { color: '#5a6a82' },
-                max: 30
-              },
-              y: {
-                grid: { display: false },
-                ticks: { color: '#eef0f5' }
-              }
-            }
-          }
-        });
       }
     } catch (e) {
       showResult('scoreResult', '⚠ Could not reach server.');

--- a/utils/money_score.py
+++ b/utils/money_score.py
@@ -1,4 +1,6 @@
 def calculate_money_score(income, expenses, savings, investments, debt, emergency_fund):
+    """Backwards-compatible numeric Money Score (0-100)."""
+
 
     score = 0
 
@@ -39,3 +41,221 @@ def calculate_money_score(income, expenses, savings, investments, debt, emergenc
         score += 5
 
     return round(score)
+
+
+from typing import Dict, List, Tuple
+
+
+def _component_status_by_score(score: int, tiers: List[Tuple[int, int]]):
+    """Return a human label based on which tier bucket matched.
+
+    tiers: list of (min_points_inclusive, status_label)
+    """
+    for min_points, label in tiers:
+        if score >= min_points:
+            return label
+    return 'fair'
+
+
+def calculate_money_score_breakdown(income, expenses, savings, investments, debt, emergency_fund) -> Dict:
+    """Return a detailed Financial Health breakdown for UI deep-dive."""
+
+    income = float(income or 0)
+    expenses = float(expenses or 0)
+    savings = float(savings or 0)
+    investments = float(investments or 0)
+    debt = float(debt or 0)
+    emergency_fund = float(emergency_fund or 0)
+
+    # Derived metrics
+    savings_rate = savings / income if income > 0 else 0.0
+    invest_rate = investments / income if income > 0 else 0.0
+    debt_ratio = debt / income if income > 0 else (1.0 if debt > 0 else 0.0)
+    months_cover = emergency_fund / expenses if expenses > 0 else (12.0 if emergency_fund > 0 else 0.0)
+
+    # Tiering rules (match existing calculate_money_score thresholds)
+    def savings_component():
+        if savings_rate >= 0.3:
+            score = 30
+            tier = '>= 30%'
+        elif savings_rate >= 0.2:
+            score = 20
+            tier = '20%–29%'
+        else:
+            score = 10
+            tier = '< 20%'
+
+        tips = [
+            'If feasible, automate savings the day you get paid.',
+            'Aim to increase savings rate by 2–5 percentage points over the next 8–12 weeks.',
+        ]
+        if savings_rate < 0.2:
+            tips.insert(0, 'Start by reducing 1 non-essential expense category (small wins matter).')
+        return {
+            'key': 'savings_rate',
+            'label': 'Savings Rate',
+            'weight': 30,
+            'your_value': round(savings_rate * 100, 2),
+            'unit': '% of income',
+            'tier': tier,
+            'score': score,
+            'max_score': 30,
+            'interpretation': 'excellent' if score == 30 else 'good' if score == 20 else 'needs_improvement',
+            'tips': tips,
+            'calculation': 'Savings Rate = Monthly Savings / Monthly Income'
+        }
+
+    def investment_component():
+        if invest_rate >= 0.2:
+            score = 25
+            tier = '>= 20%'
+        elif invest_rate >= 0.1:
+            score = 15
+            tier = '10%–19%'
+        else:
+            score = 5
+            tier = '< 10%'
+
+        tips = [
+            'Increase investment contributions gradually (e.g., +1% of income per month).',
+            'Prioritize diversified, low-cost index funds/ETFs for long-term growth.',
+        ]
+        if invest_rate < 0.1:
+            tips.insert(0, 'Set an “investment minimum” (even if small) so you keep the habit consistent.')
+        return {
+            'key': 'investment_rate',
+            'label': 'Investment Rate',
+            'weight': 25,
+            'your_value': round(invest_rate * 100, 2),
+            'unit': '% of income',
+            'tier': tier,
+            'score': score,
+            'max_score': 25,
+            'interpretation': 'excellent' if score == 25 else 'good' if score == 15 else 'needs_improvement',
+            'tips': tips,
+            'calculation': 'Investment Rate = Monthly Investments / Monthly Income'
+        }
+
+    def debt_component():
+        # Lower is better
+        if debt_ratio <= 0.2:
+            score = 25
+            tier = '<= 20%'
+        elif debt_ratio <= 0.4:
+            score = 15
+            tier = '20%–40%'
+        else:
+            score = 5
+            tier = '> 40%'
+
+        tips = [
+            'Consider refinancing to reduce interest cost (if available).',
+            'Choose a payoff order (high-interest first) to reduce interest drag.',
+        ]
+        if debt_ratio > 0.4:
+            tips.insert(0, 'Reduce debt payments pressure: focus on paying down the highest-interest loan first.')
+        elif debt_ratio > 0.2:
+            tips.insert(0, 'Try extra principal payments whenever cashflow allows.')
+
+        return {
+            'key': 'debt_ratio',
+            'label': 'Debt-to-Income Ratio (DTI)',
+            'weight': 25,
+            'your_value': round(debt_ratio * 100, 2),
+            'unit': '% of income',
+            'tier': tier,
+            'score': score,
+            'max_score': 25,
+            'interpretation': 'excellent' if score == 25 else 'good' if score == 15 else 'needs_improvement',
+            'tips': tips,
+            'calculation': 'Debt Ratio = Total Debt / Monthly Income (proxy used by this scorer)'
+        }
+
+    def emergency_component():
+        # Higher is better
+        if months_cover >= 6:
+            score = 20
+            tier = '>= 6 months'
+        elif months_cover >= 3:
+            score = 10
+            tier = '3–5 months'
+        else:
+            score = 5
+            tier = '< 3 months (or none)'
+
+        tips = [
+            'Keep emergency funds in low-volatility options (e.g., savings/overnight funds).',
+            'Set a monthly top-up amount until you reach 3 months, then 6 months.',
+        ]
+        if months_cover < 3 and emergency_fund > 0:
+            tips.insert(0, 'Aim to double your emergency fund over the next 6–9 months by redirecting small surpluses.')
+        elif months_cover == 0:
+            tips.insert(0, 'Start with a “starter buffer” (₹25k–₹50k) before optimizing other goals.')
+
+        return {
+            'key': 'emergency_coverage',
+            'label': 'Emergency Fund Coverage',
+            'weight': 20,
+            'your_value': round(months_cover, 2),
+            'unit': 'months of expenses',
+            'tier': tier,
+            'score': score,
+            'max_score': 20,
+            'interpretation': 'excellent' if score == 20 else 'good' if score == 10 else 'needs_improvement',
+            'tips': tips,
+            'calculation': 'Months Cover = Emergency Fund / Monthly Expenses (special case: expenses=0)'
+        }
+
+    components = [
+        savings_component(),
+        investment_component(),
+        debt_component(),
+        emergency_component(),
+    ]
+
+    score = round(sum(c['score'] for c in components))
+    if score >= 80:
+        status = 'Excellent 💚'
+        grade = 'A'
+    elif score >= 60:
+        status = 'Good 👍'
+        grade = 'B'
+    elif score >= 40:
+        status = 'Average ⚠️'
+        grade = 'C'
+    else:
+        status = 'Needs Improvement ❌'
+        grade = 'D'
+
+    # Anonymous peer benchmarks (simple, deterministic approximations)
+    peer_benchmarks = {
+        'savings_rate': 0.23,      # 23%
+        'investment_rate': 0.12,   # 12%
+        'debt_ratio': 0.32,        # 32%
+        'emergency_coverage': 4.0  # 4 months
+    }
+
+    key_to_peer = {
+        'savings_rate': peer_benchmarks['savings_rate'] * 100,
+        'investment_rate': peer_benchmarks['investment_rate'] * 100,
+        'debt_ratio': peer_benchmarks['debt_ratio'] * 100,
+        'emergency_coverage': peer_benchmarks['emergency_coverage']
+    }
+
+    for c in components:
+        peer_val = key_to_peer.get(c['key'], None)
+        c['peer_benchmark_value'] = peer_val
+        c['peer_benchmark_text'] = None
+        if peer_val is not None:
+            if c['unit'] == '% of income':
+                c['peer_benchmark_text'] = f"Peers ~ {round(peer_val, 2)}%"
+            else:
+                c['peer_benchmark_text'] = f"Peers ~ {round(peer_val, 2)} months"
+
+    return {
+        'score': score,
+        'status': status,
+        'grade': grade,
+        'components': components,
+        'generated_at': datetime.utcnow().isoformat() if 'datetime' in globals() else None
+    }

--- a/utils/portfolio_optimizer.py
+++ b/utils/portfolio_optimizer.py
@@ -204,77 +204,170 @@ class PortfolioOptimizer:
         return self.returns_data.corr()
     
     def stress_test(self, scenario: str = 'mild_crash') -> Dict:
-        """
-        Stress test portfolio under different scenarios
-        
+        """Historical stress test with scenario mapping.
+
+        This runs a historical simulation using the stored `returns_data`:
+        - computes portfolio daily returns from current weights
+        - finds an analogous worst/bull window depending on scenario
+        - returns drawdown metrics + a portfolio value path for visualization
+
+        If historical simulation fails for any reason, falls back to the
+        original fixed-impact approach.
+
         Scenarios:
-        - 'mild_crash': -15% market drop
-        - 'severe_crash': -30% market drop
-        - 'recession': -20% market drop
-        - 'bull_run': +25% market rally
-        - 'inflation': +10% inflation impact
-        - 'rate_hike': +2% interest rate hike
+        - 'mild_crash': analog window from mild drawdowns
+        - 'severe_crash': analog window from severe drawdowns (like 2008)
+        - 'recession': analog window from recession-like drawdowns
+        - 'bull_run': analog window from best-performing periods
+        - 'inflation': analog window from inflation-pressure drawdowns
+        - 'rate_hike': analog window from rate-hike pressure drawdowns
         """
+
         scenarios = {
-            'mild_crash': {
-                'name': 'Mild Market Crash',
-                'impact': -0.15,
-                'description': '15% market correction'
-            },
-            'severe_crash': {
-                'name': 'Severe Market Crash',
-                'impact': -0.30,
-                'description': '30% market crash (like 2008)'
-            },
-            'recession': {
-                'name': 'Economic Recession',
-                'impact': -0.20,
-                'description': '20% decline during recession'
-            },
-            'bull_run': {
-                'name': 'Bull Market Run',
-                'impact': 0.25,
-                'description': '25% market rally'
-            },
-            'inflation': {
-                'name': 'High Inflation',
-                'impact': -0.10,
-                'description': '10% erosion due to inflation'
-            },
-            'rate_hike': {
-                'name': 'Interest Rate Hike',
-                'impact': -0.08,
-                'description': '8% impact from rate hike'
-            }
+            'mild_crash': {'name': 'Mild Market Crash', 'description': 'Analog window from mild drawdowns', 'quantile': 0.20, 'window': 10, 'direction': 'down'},
+            'severe_crash': {'name': 'Severe Market Crash', 'description': 'Analog window from severe drawdowns (like 2008)', 'quantile': 0.10, 'window': 30, 'direction': 'down'},
+            'recession': {'name': 'Economic Recession', 'description': 'Analog window from recession-like drawdowns', 'quantile': 0.15, 'window': 20, 'direction': 'down'},
+            'bull_run': {'name': 'Bull Market Run', 'description': 'Analog window from best-performing periods', 'quantile': 0.10, 'window': 20, 'direction': 'up'},
+            'inflation': {'name': 'High Inflation', 'description': 'Analog window from inflation-pressure drawdowns', 'quantile': 0.18, 'window': 15, 'direction': 'down'},
+            'rate_hike': {'name': 'Interest Rate Hike', 'description': 'Analog window from rate-hike pressure drawdowns', 'quantile': 0.20, 'window': 10, 'direction': 'down'},
         }
-        
+
         scenario_data = scenarios.get(scenario, scenarios['mild_crash'])
-        
-        # Calculate impact on each holding (assuming beta=1 for simplicity)
-        current_value = self.total_value
-        impacted_value = current_value * (1 + scenario_data['impact'])
-        
-        # Calculate loss amount
-        loss = current_value - impacted_value
-        
-        return {
-            'scenario': scenario_data['name'],
-            'description': scenario_data['description'],
-            'impact_percent': scenario_data['impact'] * 100,
-            'current_value': current_value,
-            'impacted_value': impacted_value,
-            'loss': loss,
-            'loss_percent': (loss / current_value) * 100 if current_value > 0 else 0,
-            'holdings': [
-                {
-                    'symbol': h['symbol'],
-                    'current_value': h['quantity'] * h['current_price'],
-                    'stressed_value': (h['quantity'] * h['current_price']) * (1 + scenario_data['impact']),
-                    'loss': (h['quantity'] * h['current_price']) * scenario_data['impact']
-                }
-                for h in self.holdings
-            ]
-        }
+
+        try:
+            if self.returns_data is None:
+                self.fetch_historical_data()
+
+            if self.returns_data is None or self.returns_data.empty:
+                raise ValueError("No historical returns data")
+
+            weights = np.array(self.current_weights)
+
+            # Compute portfolio daily return series from stored asset returns
+            asset_matrix = self.returns_data.fillna(0.0).values
+            portfolio_daily_returns = asset_matrix.dot(weights)
+            portfolio_daily_returns = pd.Series(portfolio_daily_returns, index=self.returns_data.index)
+
+            direction = scenario_data.get('direction', 'down')
+            q = float(scenario_data['quantile'])
+            w = int(scenario_data['window'])
+            if w <= 1:
+                w = 2
+
+            # Identify candidate regime days by tail quantile
+            if direction == 'up':
+                candidate_mask = portfolio_daily_returns >= portfolio_daily_returns.quantile(1 - q)
+            else:
+                candidate_mask = portfolio_daily_returns <= portfolio_daily_returns.quantile(q)
+
+            # Rolling cumulative return for window selection
+            roll_cum = (1 + portfolio_daily_returns).rolling(window=w).apply(np.prod, raw=False) - 1
+            roll_cum = roll_cum.dropna()
+
+            if roll_cum.empty:
+                raise ValueError("Unable to compute rolling stress returns")
+
+            # Only consider windows whose end date lands on a candidate day
+            candidate_end_idx = candidate_mask[candidate_mask].index.intersection(roll_cum.index)
+            if len(candidate_end_idx) == 0:
+                candidate_end_idx = roll_cum.index
+
+            if direction == 'up':
+                end_idx = roll_cum.loc[candidate_end_idx].idxmax()
+            else:
+                end_idx = roll_cum.loc[candidate_end_idx].idxmin()
+
+            end_pos = portfolio_daily_returns.index.get_loc(end_idx)
+            start_pos = max(0, end_pos - (w - 1))
+            window_returns = portfolio_daily_returns.iloc[start_pos:end_pos + 1]
+
+            start_value = float(self.total_value)
+
+            # Build value path
+            value_path = [start_value]
+            current_value = start_value
+            for r in window_returns.values:
+                current_value = current_value * (1 + float(r))
+                value_path.append(current_value)
+
+            # Align dates with value_path (start + each day)
+            dates = [window_returns.index[0]] + list(window_returns.index)
+            value_series = pd.Series(value_path, index=pd.DatetimeIndex(dates))
+
+            peak = float(value_series.max())
+            trough = float(value_series.min())
+            max_drawdown = ((trough - peak) / peak * 100.0) if peak > 0 else 0.0
+
+            window_total_return_pct = (float(value_series.iloc[-1]) / start_value - 1) * 100.0
+            worst_day_return_pct = float(window_returns.min()) * 100.0
+
+            impacted_value = float(value_series.iloc[-1])
+            loss = float(self.total_value - impacted_value)
+
+            return {
+                'scenario': scenario_data['name'],
+                'description': scenario_data['description'],
+                'impact_percent': window_total_return_pct,
+                'current_value': float(self.total_value),
+                'impacted_value': impacted_value,
+                'loss': loss,
+                'loss_percent': (loss / float(self.total_value)) * 100.0 if float(self.total_value) > 0 else 0.0,
+                'max_drawdown_percent': float(max_drawdown),
+                'worst_day_return_percent': float(worst_day_return_pct),
+                'portfolio_path': [
+                    {'date': str(d.date()), 'value': float(v)}
+                    for d, v in value_series.items()
+                ],
+                'holdings': [
+                    {
+                        'symbol': h['symbol'],
+                        'current_value': h['quantity'] * h['current_price'],
+                        # Approximate stressed holding value proportionally to portfolio window move
+                        'stressed_value': (h['quantity'] * h['current_price']) * (1 + (window_total_return_pct / 100.0)),
+                        'loss': (h['quantity'] * h['current_price']) * (window_total_return_pct / 100.0)
+                    }
+                    for h in self.holdings
+                ]
+            }
+
+        except Exception:
+            # Fallback to original fixed-impact model
+            fixed_scenarios = {
+                'mild_crash': {'impact': -0.15, 'name': 'Mild Market Crash', 'description': '15% market correction'},
+                'severe_crash': {'impact': -0.30, 'name': 'Severe Market Crash', 'description': '30% market crash (like 2008)'},
+                'recession': {'impact': -0.20, 'name': 'Economic Recession', 'description': '20% decline during recession'},
+                'bull_run': {'impact': 0.25, 'name': 'Bull Market Run', 'description': '25% market rally'},
+                'inflation': {'impact': -0.10, 'name': 'High Inflation', 'description': '10% erosion due to inflation'},
+                'rate_hike': {'impact': -0.08, 'name': 'Interest Rate Hike', 'description': '8% impact from rate hike'},
+            }
+
+            scenario_data = fixed_scenarios.get(scenario, fixed_scenarios['mild_crash'])
+            current_value = float(self.total_value)
+            impacted_value = current_value * (1 + scenario_data['impact'])
+            loss = current_value - impacted_value
+
+            return {
+                'scenario': scenario_data['name'],
+                'description': scenario_data['description'],
+                'impact_percent': scenario_data['impact'] * 100,
+                'current_value': current_value,
+                'impacted_value': impacted_value,
+                'loss': loss,
+                'loss_percent': (loss / current_value) * 100 if current_value > 0 else 0,
+                'max_drawdown_percent': None,
+                'worst_day_return_percent': None,
+                'portfolio_path': [],
+                'holdings': [
+                    {
+                        'symbol': h['symbol'],
+                        'current_value': h['quantity'] * h['current_price'],
+                        'stressed_value': (h['quantity'] * h['current_price']) * (1 + scenario_data['impact']),
+                        'loss': (h['quantity'] * h['current_price']) * scenario_data['impact']
+                    }
+                    for h in self.holdings
+                ]
+            }
+
     
     def get_rebalancing_suggestions(self, threshold: float = 0.05) -> Dict:
         """


### PR DESCRIPTION
Implemented “Financial Health Score Deep Dive” for the Money Score.

Backend:

Updated utils/money_score.py:
Kept calculate_money_score() fully backward-compatible (tests pass).
Added calculate_money_score_breakdown(...) which returns component-level details (threshold tier, your value, interpretation, max score, calculation string, personalized tips) plus anonymous peer benchmark targets.
Updated /money-score endpoint in app.py to return:
{ score, status } (existing frontend contract)
breakdown: detailed component breakdown
peers: anonymous benchmark payload
Frontend:

Updated templates/score.html:
Replaced the previous Chart.js-based breakdown with a dashboard driven by data.breakdown.
Added “Deep Dive” expand/collapse sections per component (Savings Rate, Investment Rate, Debt Ratio/DTI, Emergency Fund Coverage) showing calculation, peer benchmark, and personalized tips.


closes #407