### PR TITLE
fix: resolve unexpected text cursor and disable text selection on dashboard metric labels

### DIFF
--- a/templates/score.html
+++ b/templates/score.html
@@ -3,6 +3,14 @@
 {% block title %}Money Score{% endblock %}
 
 {% block content %}
+<style>
+  .form-grid label {
+    cursor: default;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+</style>
 <div id="score" class="page active">
   <div class="page-title">Money <span>Score</span></div>
   <div style="display: grid; grid-template-columns: 1fr 1.2fr; gap: 20px; align-items: start; max-width: 900px;">


### PR DESCRIPTION
### Overview
This PR resolves the user interface layout bug where hovering over static dashboard financial statistics metrics (such as Monthly Income, Expenses, Savings, etc.) unexpectedly triggered a text-selection cursor (`text` / I-beam) and allowed accidental text highlighting.

### Changes Made
- Added a targeted CSS rule inside `templates/score.html` for `.form-grid label`.
- Enforced `cursor: default;` to maintain standard pointer consistency across static monitoring elements.
- Applied `user-select: none;` (along with vendor prefixes for Safari/Edge) to eliminate accidental highlighting or flickering artifacts during quick interactions.

### Impact
- Ensures a cohesive, solid component experience across the entire informational container grid.
- Eliminates unstyled text block behaviors, matching the visual polish expected from a structured dashboard layout.

Closes #425 