### PR TITLE
fix: dedup Flask init (#418) + add /login rate limiting & lockout (#420)

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,6 +60,57 @@ app = Flask(__name__)
 # ---------------- INIT SOCKETIO ----------------
 socketio = SocketIO(app, cors_allowed_origins="*")
 
+# ---------------- RATE LIMITING ----------------
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+# Per-route, opt-in limiter (no global default limits). Uses in-memory
+# storage which is fine for single-process/dev; swap storage_uri for Redis
+# in a multi-process production deployment.
+limiter = Limiter(
+    key_func=get_remote_address,
+    app=app,
+    storage_uri="memory://",
+)
+
+
+@app.errorhandler(429)
+def ratelimit_handler(e):
+    return jsonify({
+        "error": "Too many requests. Please slow down and try again later."
+    }), 429
+
+
+# ---- Account lockout (brute-force protection) ----
+# After LOGIN_MAX_FAILED_ATTEMPTS consecutive failed logins for a given
+# username, further attempts are blocked for LOGIN_LOCKOUT_SECONDS.
+LOGIN_MAX_FAILED_ATTEMPTS = 5
+LOGIN_LOCKOUT_SECONDS = 15 * 60
+_failed_login_attempts = {}  # username -> {"count": int, "locked_until": datetime|None}
+
+
+def _is_locked_out(username):
+    record = _failed_login_attempts.get(username)
+    if not record:
+        return False
+    locked_until = record.get("locked_until")
+    return bool(locked_until and datetime.utcnow() < locked_until)
+
+
+def _register_failed_login(username):
+    record = _failed_login_attempts.setdefault(
+        username, {"count": 0, "locked_until": None}
+    )
+    record["count"] += 1
+    if record["count"] >= LOGIN_MAX_FAILED_ATTEMPTS:
+        record["locked_until"] = datetime.utcnow() + timedelta(
+            seconds=LOGIN_LOCKOUT_SECONDS
+        )
+
+
+def _reset_failed_login(username):
+    _failed_login_attempts.pop(username, None)
+
 # ---------------- IMPORT MODELS ----------------
 from models import (
     db, Expense, Asset, Liability, BudgetLimit, BudgetAlert, 
@@ -374,31 +425,11 @@ def process_recurring_incomes():
         db.session.rollback()
         print(f"❌ Error processing recurring incomes: {e}")
 
-# ---------------- INIT DATABASE ----------------
-from models import db, Expense, Asset, Liability, BudgetLimit, BudgetAlert, PriceAlert, PriceAlertEvent, FinancialGoal, RecurringExpense, Portfolio, FxRateCache, FinancialGoalMilestone, RecurringIncome, IncomeOccurrence, MilestoneNotification, SipSchedule
-
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///money_mentor.db"
-app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-app.config["SECRET_KEY"] = os.getenv(
-    "SECRET_KEY",
-    "dev-secret-key"
-)
-from flask_login import LoginManager
-
-login_manager = LoginManager()
-login_manager.init_app(app)
-db.init_app(app)
-
-from models import User
-
-with app.app_context():
-    db.create_all()
-
-# ---------------- INIT SAFETY ENGINE ----------------
-safety_engine = SafetyEngine()
-
 # ---------------- INIT GROQ ----------------
-# client is initialized in the startup validation block above
+# App config, extensions (Mail, LoginManager, db) and the user loader are
+# initialized once near the top of this module (see the DATABASE/EMAIL
+# config blocks). The Groq `client` is initialized in the startup
+# validation block above.
 
 # ── Dev-mode startup message ─────────────────────────────────
 if os.getenv("FLASK_ENV", "development") != "production":
@@ -406,10 +437,6 @@ if os.getenv("FLASK_ENV", "development") != "production":
         print("[OK] Groq client initialised successfully.")
     else:
         print("[WARNING] Groq client is running in offline mode.")
-
-@login_manager.user_loader
-def load_user(user_id):
-    return db.session.get(User, int(user_id))
 
 @app.before_request
 def auto_login():
@@ -601,6 +628,7 @@ def register():
     return jsonify({"status": "success"})
 
 @app.route("/login", methods=["POST"])
+@limiter.limit("5 per minute")
 def login():
     data = request.json or {}
     username = data.get("username")
@@ -608,11 +636,21 @@ def login():
     password = data.get("password")
     if not username or not password or not email:
         return jsonify({"error": "Username, email, and password are required."}), 400
-    
+
+    # Block accounts that have hit the failed-attempt threshold.
+    if _is_locked_out(username):
+        return jsonify({
+            "error": "Account temporarily locked due to too many failed "
+                     "login attempts. Please try again later."
+        }), 429
+
     user = User.query.filter_by(username=username).first()
     if user and check_password_hash(user.password_hash, password):
+        _reset_failed_login(username)
         login_user(user)
         return jsonify({"status": "success"})
+
+    _register_failed_login(username)
     return jsonify({"error": "Invalid username or password."}), 401
 
 @app.route("/logout", methods=["POST"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ flask-sqlalchemy==3.1.1
 apscheduler==3.11.2
 fpdf2==2.8.7
 flask-login
+flask-limiter==3.8.0
 werkzeug
 flask-mail==0.10.0
 

--- a/tests/test_login_rate_limit.py
+++ b/tests/test_login_rate_limit.py
@@ -1,0 +1,98 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock out external libraries that are not installed before importing app
+sys.modules['yfinance'] = MagicMock()
+sys.modules['groq'] = MagicMock()
+sys.modules['pdfplumber'] = MagicMock()
+
+from werkzeug.security import generate_password_hash
+
+from app import app, db, limiter
+from app import LOGIN_MAX_FAILED_ATTEMPTS
+import app as app_module
+from models import User
+
+
+class TestLoginRateLimitAndLockout(unittest.TestCase):
+    """Tests for brute-force protection on the /login route (issue #420)."""
+
+    def setUp(self):
+        app.config["TESTING"] = True
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        app.config["RATELIMIT_ENABLED"] = True
+
+        self.client = app.test_client()
+        self.app_context = app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        # Known user with a real password hash so a correct login can succeed.
+        user = User(
+            username="victim",
+            email="victim@example.com",
+            password_hash=generate_password_hash("correct-horse"),
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        # Start every test from a clean slate.
+        limiter.reset()
+        app_module._failed_login_attempts.clear()
+
+    def tearDown(self):
+        limiter.reset()
+        app_module._failed_login_attempts.clear()
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def _attempt(self, username, password="wrong"):
+        return self.client.post("/login", json={
+            "username": username,
+            "email": f"{username}@example.com",
+            "password": password,
+        })
+
+    def test_rate_limit_returns_429_after_threshold(self):
+        """The 6th request within the window is throttled with 429."""
+        # Use distinct usernames so the per-account lockout never triggers;
+        # the limiter keys on the client IP, so these all share one bucket.
+        for i in range(5):
+            resp = self._attempt(f"user{i}")
+            self.assertEqual(resp.status_code, 401, f"attempt {i} should be 401")
+
+        resp = self._attempt("user5")
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("Too many requests", resp.get_json()["error"])
+
+    def test_account_lockout_after_failed_attempts(self):
+        """After N failed attempts for one user, further attempts are locked."""
+        # Disable the IP rate limiter so we exercise the lockout path directly.
+        app.config["RATELIMIT_ENABLED"] = False
+
+        for i in range(LOGIN_MAX_FAILED_ATTEMPTS):
+            resp = self._attempt("victim")
+            self.assertEqual(resp.status_code, 401, f"attempt {i} should be 401")
+
+        # Account is now locked: even the correct password is rejected.
+        resp = self._attempt("victim", password="correct-horse")
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("locked", resp.get_json()["error"].lower())
+
+    def test_successful_login_resets_failed_counter(self):
+        """A successful login clears prior failed attempts so no lockout."""
+        app.config["RATELIMIT_ENABLED"] = False
+
+        # A few failures, but below the threshold.
+        for _ in range(LOGIN_MAX_FAILED_ATTEMPTS - 1):
+            self._attempt("victim")
+
+        resp = self._attempt("victim", password="correct-horse")
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("victim", app_module._failed_login_attempts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #418
Closes #420

## #418 — Flask app config & extensions initialized twice
Removed the duplicate initialization block (`SQLALCHEMY_DATABASE_URI`,
`SQLALCHEMY_TRACK_MODIFICATIONS`, `SECRET_KEY`, `LoginManager`,
`db.init_app`, `db.create_all`, and the `@login_manager.user_loader`).
These are already configured once near the top of the module; only the
redundant second copy was dropped. The unique dev-mode Groq startup
message that lived in that block was preserved.

## #420 — No rate limiting on /login (brute-force risk)
- Added **Flask-Limiter** with `@limiter.limit("5 per minute")` on `/login`
  and a JSON `429` error handler.
- Added a **per-account lockout**: after 5 consecutive failed logins a
  username is locked for 15 minutes; the counter resets on a successful
  login.
- Added `flask-limiter==3.8.0` to `requirements.txt`.
- Added `tests/test_login_rate_limit.py` covering throttling (429 after
  threshold), account lockout, and counter reset on success.

## ⚠️ Verification / CI note
`main`'s `app.py` is currently **pre-broken, independent of this PR** — it
contains duplicated/interleaved copies of the same code (e.g. `settings`
defined 5×; `parse_document`, `analyze_portfolio` and many routes
registered 2–5×) and does **not compile or import**. Because of that:
- CI on this branch is expected to fail until `app.py` is rebuilt from a
  single known-good copy.
- These changes could not be run/verified locally for the same reason.

The diffs above are scoped strictly to #418 and #420 and are correct
against the file's intended logic. Recommend the maintainers restore
`app.py` to a compiling state (separate repo-health task) so this can be
verified and merged.
