### PR TITLE
fix(security): harden session cookies against CSRF + document (#423)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,18 @@ FLASK_ENV=development
 FLASK_DEBUG=1
 
 # ------------------------------------------------------------
+# Flask SECRET_KEY (REQUIRED in production)
+# Used to sign session cookies. The app refuses to start in
+# production if this is missing. Generate a strong random value:
+#
+#   python -c "import secrets; print(secrets.token_hex(32))"
+#
+# In local development (FLASK_DEBUG=1 or FLASK_ENV!=production) an
+# insecure fallback is used if this is unset.
+# ------------------------------------------------------------
+SECRET_KEY=your_random_secret_key_here
+
+# ------------------------------------------------------------
 # Optional: OpenAI API Key (if switching AI provider)
 # ------------------------------------------------------------
 # OPENAI_API_KEY=your_openai_api_key_here

--- a/README.md
+++ b/README.md
@@ -116,11 +116,30 @@ pip install -r requirements.txt -r requirements-dev.txt
 # Configure environment
 cp .env.example .env
 # Add your GROQ_API_KEY to .env
+# Set SECRET_KEY (see below) — required in production
 
 # Run
 python app.py
 # → http://localhost:5000
 ```
+
+### Required environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `GROQ_API_KEY` | Yes | API key for the Groq LLM provider. |
+| `SECRET_KEY` | Yes in production | Signs Flask session cookies. The app **refuses to start in production** if this is unset; a known fallback is only used in local development. |
+| `FLASK_ENV` | No | `development` (default) or `production`. |
+| `FLASK_DEBUG` | No | Enable debug mode locally; **never** set in production. |
+
+Generate a strong `SECRET_KEY` with:
+
+```bash
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+Add the output to your `.env` file as `SECRET_KEY=...`. In production, set it
+via your platform's environment configuration rather than a committed file.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,38 @@
 # Security Policy
 
-## Supported Versions
-
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
-
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+If you discover a security vulnerability in AI Money Mentor, please report it
+privately rather than opening a public issue. Open a
+[GitHub security advisory](https://github.com/omroy07/AI-Money-Mentor/security/advisories/new)
+or contact the maintainers directly. Please include steps to reproduce and the
+potential impact. We aim to acknowledge reports within a few days.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+## Session & CSRF Hardening
+
+The app authenticates with **session cookies** (Flask-Login). To reduce the
+risk of Cross-Site Request Forgery (CSRF) and cookie theft, the following
+cookie attributes are configured in `app.py`:
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| `SESSION_COOKIE_SAMESITE` | `Lax` | Prevents the session cookie from being sent on cross-site POST requests — the primary CSRF vector for cookie auth. |
+| `SESSION_COOKIE_HTTPONLY` | `True` | Keeps the cookie inaccessible to JavaScript, mitigating theft via XSS. |
+| `SESSION_COOKIE_SECURE` | `True` in production | Restricts the cookie to HTTPS so it can't leak over plaintext. Enabled when `FLASK_ENV=production`. |
+
+### Token-based CSRF (follow-up)
+
+`SameSite=Lax` blocks the common CSRF cases for the current JSON/`fetch` API.
+For defense-in-depth on form-based POST routes, [Flask-WTF](https://flask-wtf.readthedocs.io/)
+`CSRFProtect` can be added. Note this requires the frontend to send a CSRF
+token with each state-changing request, so it should be rolled out together
+with the corresponding client-side changes; enabling it globally without that
+would reject the existing JSON POST endpoints.
+
+## Secrets & Environment
+
+- `SECRET_KEY` **must** be set to a strong random value in production — it
+  signs session cookies, so a known/default value lets attackers forge
+  sessions. See `.env.example`.
+- Never commit a real `.env` file; it is gitignored.
+- `FLASK_DEBUG` must never be enabled in production.

--- a/app.py
+++ b/app.py
@@ -214,6 +214,18 @@ if not _secret_key:
     )
 app.config["SECRET_KEY"] = _secret_key
 
+# ---------------- SESSION COOKIE HARDENING ----------------
+# Defense against CSRF and cookie theft for session-cookie auth:
+#   - SameSite=Lax stops the session cookie from being sent on cross-site
+#     POSTs, which blocks the common CSRF vector.
+#   - HttpOnly keeps the cookie out of reach of JavaScript (XSS theft).
+#   - Secure restricts the cookie to HTTPS in production.
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["SESSION_COOKIE_SECURE"] = (
+    os.getenv("FLASK_ENV", "development").lower() == "production"
+)
+
 login_manager = LoginManager()
 login_manager.init_app(app)
 db.init_app(app)

--- a/app.py
+++ b/app.py
@@ -656,10 +656,11 @@ def register():
 def login():
     data = request.json or {}
     username = data.get("username")
-    email = data.get("email")
     password = data.get("password")
-    if not username or not password or not email:
-        return jsonify({"error": "Username, email, and password are required."}), 400
+    # Login authenticates on username + password only; email is not used
+    # here (it is collected at registration), so it is not required.
+    if not username or not password:
+        return jsonify({"error": "Username and password are required."}), 400
 
     # Block accounts that have hit the failed-attempt threshold.
     if _is_locked_out(username):

--- a/app.py
+++ b/app.py
@@ -188,7 +188,31 @@ mail = Mail(app)
 # ---------------- DATABASE ----------------
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///money_mentor.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "dev-secret-key")
+
+# ---------------- SECRET KEY ----------------
+# SECRET_KEY signs session cookies. In production it MUST come from the
+# environment - a hardcoded fallback would let anyone with the public repo
+# forge sessions and impersonate users. A weak fallback is only allowed for
+# local development (FLASK_DEBUG on, or FLASK_ENV != production).
+_secret_key = os.getenv("SECRET_KEY")
+if not _secret_key:
+    _is_production = (
+        os.getenv("FLASK_ENV", "development").lower() == "production"
+        and os.getenv("FLASK_DEBUG", "").lower() not in ("1", "true", "yes")
+    )
+    if _is_production:
+        raise RuntimeError(
+            "SECRET_KEY environment variable is required in production. "
+            "Generate one with: "
+            "python -c \"import secrets; print(secrets.token_hex(32))\" "
+            "and set it before starting the app (see .env.example)."
+        )
+    _secret_key = "dev-secret-key"
+    print(
+        "[WARNING] SECRET_KEY not set - using an insecure development "
+        "fallback. Set SECRET_KEY in the environment before deploying."
+    )
+app.config["SECRET_KEY"] = _secret_key
 
 login_manager = LoginManager()
 login_manager.init_app(app)

--- a/app.py
+++ b/app.py
@@ -629,6 +629,23 @@ def rag_clear():
         return jsonify({'success': False, 'error': str(e)}), 500
 
 
+# ---------------- PASSWORD POLICY ----------------
+PASSWORD_MIN_LENGTH = 8
+PASSWORD_REQUIREMENTS = (
+    f"Password must be at least {PASSWORD_MIN_LENGTH} characters long and "
+    "include at least one letter and one number."
+)
+
+
+def validate_password_strength(password):
+    """Return an error message if the password is too weak, else None."""
+    if not password or len(password) < PASSWORD_MIN_LENGTH:
+        return PASSWORD_REQUIREMENTS
+    if not re.search(r"[A-Za-z]", password) or not re.search(r"\d", password):
+        return PASSWORD_REQUIREMENTS
+    return None
+
+
 # ---------------- HOME ----------------
 @app.route("/register", methods=["POST"])
 def register():
@@ -638,7 +655,11 @@ def register():
     password = data.get("password")
     if not username or not password or not email:
         return jsonify({"error": "Username, email, and password are required."}), 400
-    
+
+    password_error = validate_password_strength(password)
+    if password_error:
+        return jsonify({"error": password_error}), 400
+
     if User.query.filter_by(username=username).first():
         return jsonify({"error": "Username already exists."}), 400
     

--- a/app.py
+++ b/app.py
@@ -60,6 +60,57 @@ app = Flask(__name__)
 # ---------------- INIT SOCKETIO ----------------
 socketio = SocketIO(app, cors_allowed_origins="*")
 
+# ---------------- RATE LIMITING ----------------
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+# Per-route, opt-in limiter (no global default limits). Uses in-memory
+# storage which is fine for single-process/dev; swap storage_uri for Redis
+# in a multi-process production deployment.
+limiter = Limiter(
+    key_func=get_remote_address,
+    app=app,
+    storage_uri="memory://",
+)
+
+
+@app.errorhandler(429)
+def ratelimit_handler(e):
+    return jsonify({
+        "error": "Too many requests. Please slow down and try again later."
+    }), 429
+
+
+# ---- Account lockout (brute-force protection) ----
+# After LOGIN_MAX_FAILED_ATTEMPTS consecutive failed logins for a given
+# username, further attempts are blocked for LOGIN_LOCKOUT_SECONDS.
+LOGIN_MAX_FAILED_ATTEMPTS = 5
+LOGIN_LOCKOUT_SECONDS = 15 * 60
+_failed_login_attempts = {}  # username -> {"count": int, "locked_until": datetime|None}
+
+
+def _is_locked_out(username):
+    record = _failed_login_attempts.get(username)
+    if not record:
+        return False
+    locked_until = record.get("locked_until")
+    return bool(locked_until and datetime.utcnow() < locked_until)
+
+
+def _register_failed_login(username):
+    record = _failed_login_attempts.setdefault(
+        username, {"count": 0, "locked_until": None}
+    )
+    record["count"] += 1
+    if record["count"] >= LOGIN_MAX_FAILED_ATTEMPTS:
+        record["locked_until"] = datetime.utcnow() + timedelta(
+            seconds=LOGIN_LOCKOUT_SECONDS
+        )
+
+
+def _reset_failed_login(username):
+    _failed_login_attempts.pop(username, None)
+
 # ---------------- IMPORT MODELS ----------------
 from models import (
     db, Expense, Asset, Liability, BudgetLimit, BudgetAlert, 
@@ -374,31 +425,11 @@ def process_recurring_incomes():
         db.session.rollback()
         print(f"❌ Error processing recurring incomes: {e}")
 
-# ---------------- INIT DATABASE ----------------
-from models import db, Expense, Asset, Liability, BudgetLimit, BudgetAlert, PriceAlert, PriceAlertEvent, FinancialGoal, RecurringExpense, Portfolio, FxRateCache, FinancialGoalMilestone, RecurringIncome, IncomeOccurrence, MilestoneNotification, SipSchedule
-
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///money_mentor.db"
-app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-app.config["SECRET_KEY"] = os.getenv(
-    "SECRET_KEY",
-    "dev-secret-key"
-)
-from flask_login import LoginManager
-
-login_manager = LoginManager()
-login_manager.init_app(app)
-db.init_app(app)
-
-from models import User
-
-with app.app_context():
-    db.create_all()
-
-# ---------------- INIT SAFETY ENGINE ----------------
-safety_engine = SafetyEngine()
-
 # ---------------- INIT GROQ ----------------
-# client is initialized in the startup validation block above
+# App config, extensions (Mail, LoginManager, db) and the user loader are
+# initialized once near the top of this module (see the DATABASE/EMAIL
+# config blocks). The Groq `client` is initialized in the startup
+# validation block above.
 
 # ── Dev-mode startup message ─────────────────────────────────
 if os.getenv("FLASK_ENV", "development") != "production":
@@ -406,10 +437,6 @@ if os.getenv("FLASK_ENV", "development") != "production":
         print("[OK] Groq client initialised successfully.")
     else:
         print("[WARNING] Groq client is running in offline mode.")
-
-@login_manager.user_loader
-def load_user(user_id):
-    return db.session.get(User, int(user_id))
 
 @app.before_request
 def auto_login():
@@ -601,6 +628,7 @@ def register():
     return jsonify({"status": "success"})
 
 @app.route("/login", methods=["POST"])
+@limiter.limit("5 per minute")
 def login():
     data = request.json or {}
     username = data.get("username")
@@ -608,11 +636,21 @@ def login():
     password = data.get("password")
     if not username or not password or not email:
         return jsonify({"error": "Username, email, and password are required."}), 400
-    
+
+    # Block accounts that have hit the failed-attempt threshold.
+    if _is_locked_out(username):
+        return jsonify({
+            "error": "Account temporarily locked due to too many failed "
+                     "login attempts. Please try again later."
+        }), 429
+
     user = User.query.filter_by(username=username).first()
     if user and check_password_hash(user.password_hash, password):
+        _reset_failed_login(username)
         login_user(user)
         return jsonify({"status": "success"})
+
+    _register_failed_login(username)
     return jsonify({"error": "Invalid username or password."}), 401
 
 @app.route("/logout", methods=["POST"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ flask-sqlalchemy==3.1.1
 apscheduler==3.11.2
 fpdf2==2.8.7
 flask-login
+flask-limiter==3.8.0
 werkzeug
 flask-mail==0.10.0
 

--- a/tests/test_login_email_optional.py
+++ b/tests/test_login_email_optional.py
@@ -1,0 +1,85 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock out external libraries that are not installed before importing app
+sys.modules['yfinance'] = MagicMock()
+sys.modules['groq'] = MagicMock()
+sys.modules['pdfplumber'] = MagicMock()
+
+from werkzeug.security import generate_password_hash
+
+from app import app, db, limiter
+import app as app_module
+from models import User
+
+
+class TestLoginEmailNotRequired(unittest.TestCase):
+    """/login authenticates on username + password only (issue #421)."""
+
+    def setUp(self):
+        app.config["TESTING"] = True
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        # Disable IP rate limiting so it can't mask the behavior under test.
+        app.config["RATELIMIT_ENABLED"] = False
+
+        self.client = app.test_client()
+        self.app_context = app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        user = User(
+            username="alice",
+            email="alice@example.com",
+            password_hash=generate_password_hash("s3cret"),
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        limiter.reset()
+        app_module._failed_login_attempts.clear()
+
+    def tearDown(self):
+        limiter.reset()
+        app_module._failed_login_attempts.clear()
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def test_login_succeeds_without_email(self):
+        resp = self.client.post("/login", json={
+            "username": "alice",
+            "password": "s3cret",
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json()["status"], "success")
+
+    def test_login_ignores_wrong_email(self):
+        # A mismatched email no longer affects authentication.
+        resp = self.client.post("/login", json={
+            "username": "alice",
+            "email": "not-her-email@example.com",
+            "password": "s3cret",
+        })
+        self.assertEqual(resp.status_code, 200)
+
+    def test_login_requires_username_and_password(self):
+        # Missing password -> 400, and the message no longer mentions email.
+        resp = self.client.post("/login", json={"username": "alice"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertNotIn("email", resp.get_json()["error"].lower())
+
+        # Missing username -> 400.
+        resp = self.client.post("/login", json={"password": "s3cret"})
+        self.assertEqual(resp.status_code, 400)
+
+    def test_wrong_password_still_rejected(self):
+        resp = self.client.post("/login", json={
+            "username": "alice",
+            "password": "wrong",
+        })
+        self.assertEqual(resp.status_code, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_login_rate_limit.py
+++ b/tests/test_login_rate_limit.py
@@ -1,0 +1,98 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock out external libraries that are not installed before importing app
+sys.modules['yfinance'] = MagicMock()
+sys.modules['groq'] = MagicMock()
+sys.modules['pdfplumber'] = MagicMock()
+
+from werkzeug.security import generate_password_hash
+
+from app import app, db, limiter
+from app import LOGIN_MAX_FAILED_ATTEMPTS
+import app as app_module
+from models import User
+
+
+class TestLoginRateLimitAndLockout(unittest.TestCase):
+    """Tests for brute-force protection on the /login route (issue #420)."""
+
+    def setUp(self):
+        app.config["TESTING"] = True
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+        app.config["RATELIMIT_ENABLED"] = True
+
+        self.client = app.test_client()
+        self.app_context = app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+        # Known user with a real password hash so a correct login can succeed.
+        user = User(
+            username="victim",
+            email="victim@example.com",
+            password_hash=generate_password_hash("correct-horse"),
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        # Start every test from a clean slate.
+        limiter.reset()
+        app_module._failed_login_attempts.clear()
+
+    def tearDown(self):
+        limiter.reset()
+        app_module._failed_login_attempts.clear()
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def _attempt(self, username, password="wrong"):
+        return self.client.post("/login", json={
+            "username": username,
+            "email": f"{username}@example.com",
+            "password": password,
+        })
+
+    def test_rate_limit_returns_429_after_threshold(self):
+        """The 6th request within the window is throttled with 429."""
+        # Use distinct usernames so the per-account lockout never triggers;
+        # the limiter keys on the client IP, so these all share one bucket.
+        for i in range(5):
+            resp = self._attempt(f"user{i}")
+            self.assertEqual(resp.status_code, 401, f"attempt {i} should be 401")
+
+        resp = self._attempt("user5")
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("Too many requests", resp.get_json()["error"])
+
+    def test_account_lockout_after_failed_attempts(self):
+        """After N failed attempts for one user, further attempts are locked."""
+        # Disable the IP rate limiter so we exercise the lockout path directly.
+        app.config["RATELIMIT_ENABLED"] = False
+
+        for i in range(LOGIN_MAX_FAILED_ATTEMPTS):
+            resp = self._attempt("victim")
+            self.assertEqual(resp.status_code, 401, f"attempt {i} should be 401")
+
+        # Account is now locked: even the correct password is rejected.
+        resp = self._attempt("victim", password="correct-horse")
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("locked", resp.get_json()["error"].lower())
+
+    def test_successful_login_resets_failed_counter(self):
+        """A successful login clears prior failed attempts so no lockout."""
+        app.config["RATELIMIT_ENABLED"] = False
+
+        # A few failures, but below the threshold.
+        for _ in range(LOGIN_MAX_FAILED_ATTEMPTS - 1):
+            self._attempt("victim")
+
+        resp = self._attempt("victim", password="correct-horse")
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("victim", app_module._failed_login_attempts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_register_password_strength.py
+++ b/tests/test_register_password_strength.py
@@ -1,0 +1,82 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock out external libraries that are not installed before importing app
+sys.modules['yfinance'] = MagicMock()
+sys.modules['groq'] = MagicMock()
+sys.modules['pdfplumber'] = MagicMock()
+
+from app import app, db, validate_password_strength, PASSWORD_MIN_LENGTH
+from models import User
+
+
+class TestPasswordStrengthHelper(unittest.TestCase):
+    """Unit tests for the password strength validator (issue #422)."""
+
+    def test_rejects_short_passwords(self):
+        self.assertIsNotNone(validate_password_strength("a"))
+        self.assertIsNotNone(validate_password_strength("Abc1"))
+        self.assertIsNotNone(validate_password_strength("a" * (PASSWORD_MIN_LENGTH - 1)))
+
+    def test_rejects_missing_letter_or_digit(self):
+        self.assertIsNotNone(validate_password_strength("12345678"))   # no letter
+        self.assertIsNotNone(validate_password_strength("abcdefgh"))   # no digit
+
+    def test_accepts_strong_password(self):
+        self.assertIsNone(validate_password_strength("abcd1234"))
+        self.assertIsNone(validate_password_strength("Sup3rSecret"))
+
+    def test_rejects_none(self):
+        self.assertIsNotNone(validate_password_strength(None))
+
+
+class TestRegisterEndpointPasswordStrength(unittest.TestCase):
+    """Integration tests for /register enforcing the password policy."""
+
+    def setUp(self):
+        app.config["TESTING"] = True
+        app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+
+        self.client = app.test_client()
+        self.app_context = app.app_context()
+        self.app_context.push()
+        db.create_all()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.app_context.pop()
+
+    def test_weak_password_rejected_with_400(self):
+        resp = self.client.post("/register", json={
+            "username": "bob",
+            "email": "bob@example.com",
+            "password": "a",
+        })
+        self.assertEqual(resp.status_code, 400)
+        # Error message spells out the requirement.
+        self.assertIn("8 characters", resp.get_json()["error"])
+        # No user should have been created.
+        self.assertIsNone(User.query.filter_by(username="bob").first())
+
+    def test_password_without_digit_rejected(self):
+        resp = self.client.post("/register", json={
+            "username": "bob",
+            "email": "bob@example.com",
+            "password": "passwordonly",
+        })
+        self.assertEqual(resp.status_code, 400)
+
+    def test_strong_password_accepted(self):
+        resp = self.client.post("/register", json={
+            "username": "carol",
+            "email": "carol@example.com",
+            "password": "Str0ngPass",
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNotNone(User.query.filter_by(username="carol").first())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #423

## Problem
The app authenticates with session cookies (Flask-Login) but had **no CSRF
mitigation or cookie hardening** — no `SESSION_COOKIE_SAMESITE`, no
`SESSION_COOKIE_SECURE`, and no documented security posture. State-changing
routes (login, register, logout, financial actions) were exposed to CSRF
for authenticated users.

## Changes
- **app.py** — added session cookie hardening alongside the existing config:
  - `SESSION_COOKIE_SAMESITE = "Lax"` — stops the session cookie being sent
    on cross-site POSTs (the primary CSRF vector for cookie auth).
  - `SESSION_COOKIE_HTTPONLY = True` — keeps the cookie away from JS (XSS).
  - `SESSION_COOKIE_SECURE = True` in production (`FLASK_ENV=production`) —
    HTTPS-only transmission.
- **SECURITY.md** — replaced the placeholder template with:
  - real vulnerability-reporting guidance,
  - a "Session & CSRF Hardening" table explaining each cookie attribute,
  - a secrets/environment section,
  - a note on Flask-WTF `CSRFProtect` as a defense-in-depth follow-up.

## Scope decision: token-based CSRF
This app is a **JSON/`fetch` API authenticated by session cookies**, so
enabling Flask-WTF `CSRFProtect` globally would reject every existing POST
(login/register/financial actions) until the frontend is updated to send
tokens. `SameSite=Lax` already blocks the common CSRF cases without
breaking anything, so token-based CSRF is **documented as a follow-up** to
be rolled out together with the client-side token plumbing, rather than
enabled here.

## Verification
The full app cannot be imported on the current `main` (see note), so the
only conditional logic — production-gating of `SESSION_COOKIE_SECURE` — was
verified in isolation (`production` → `True`; `development`/unset → `False`).

