### PR TITLE
fix: correct static JS path for dashboard, recurring, and retirement pages

### DIFF
--- a/templates/dashboard_new.html
+++ b/templates/dashboard_new.html
@@ -112,5 +112,5 @@
 
 {% block extra_js %}
 <script src="https://cdn.socket.io/4.5.0/socket.io.min.js"></script>
-<script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
+<script src="{{ url_for('static', filename='scripts/dashboard.js') }}"></script>
 {% endblock %}

--- a/templates/recurring.html
+++ b/templates/recurring.html
@@ -321,7 +321,7 @@
   </div>
 </div>
 
-<script src="{{ url_for('static', filename='js/recurring.js') }}"></script>
+<script src="{{ url_for('static', filename='scripts/recurring.js') }}"></script>
 <script>
 function simulateCancel() {
     const modal = new bootstrap.Modal(document.getElementById('cancelModal'));

--- a/templates/retirement.html
+++ b/templates/retirement.html
@@ -227,6 +227,6 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script src="{{ url_for('static', filename='js/retirement.js') }}"></script>
+<script src="{{ url_for('static', filename='scripts/retirement.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## What this fixes

Fixes #446 

`dashboard_new.html`, `recurring.html`, and `retirement.html` were loading their scripts via:

```html
<script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
```

which resolves to `/static/js/...` - but the actual files live at `/static/scripts/...`. There is no `static/js/` directory in the repo, so all three requests 404'd silently.

## Impact

- Dashboard: drag-and-drop widgets, layout saving, and live updates never initialized.
- Recurring Transactions page: no interactivity.
- Retirement Planner: calculator logic never ran.

All three pages rendered but were effectively non-functional, with no visible error unless devtools was open.

## Changes

Updated the `url_for` `filename` argument in all three templates from `js/...` to `scripts/...` to match the actual file location.

## Testing

- Ran the app locally and opened `/dashboard_new`, `/recurring`, and `/retirement`.
- Confirmed via Network tab that all three script requests now return `200` instead of `404`.
- Confirmed page interactivity (dashboard widgets, recurring form, retirement calculator) works as expected after the fix.

No logic was touched - this is a path-only fix.