### PR TITLE
fix: correct timezone handling in due-this-week calculation

### DIFF
--- a/static/scripts/recurring.js
+++ b/static/scripts/recurring.js
@@ -94,6 +94,11 @@ function renderRecurringList(recurring) {
     html += '</tbody></table></div>';
     container.innerHTML = html;
 }
+function startOfDay(d) {
+    const x = new Date(d);
+    x.setHours(0, 0, 0, 0);
+    return x;
+}
 
 function updateStats(recurring) {
     const active = recurring.filter(r => r.is_active);
@@ -105,13 +110,13 @@ function updateStats(recurring) {
         return sum + r.amount;
     }, 0);
     
-    const today = new Date();
-    const weekLater = new Date(today);
+    const today = startOfDay(new Date());
+    const weekLater = startOfDay(new Date());
     weekLater.setDate(today.getDate() + 7);
     
     const dueThisWeek = active.filter(r => {
         if (!r.next_due_date) return false;
-        const dueDate = new Date(r.next_due_date);
+        const dueDate = startOfDay(new Date(r.next_due_date + 'T00:00:00'));
         return dueDate >= today && dueDate <= weekLater;
     });
     


### PR DESCRIPTION
## What this fixes

Fixes #447 

`updateStats()` in `static/scripts/recurring.js` computed the "Due This Week" count by comparing `today = new Date()` (current moment, including local time-of-day) against `dueDate = new Date(r.next_due_date)`, where `next_due_date` is a date-only string (`YYYY-MM-DD`) that JS parses as **UTC midnight**.

For users in a UTC+ timezone (e.g. IST, UTC+5:30), an item due "today" ends up with a `dueDate` timestamp earlier than `today`, so `dueDate >= today` evaluates to `false` - silently excluding items due today from the "Due This Week" stat.

## Changes

- Added a `startOfDay()` helper that zeroes out time-of-day on a `Date`, using local time.
- `today` and `weekLater` are now normalized to local midnight instead of the current moment.
- `next_due_date` is parsed with a `T00:00:00` suffix so JS interprets it as **local** midnight instead of UTC midnight.

This makes the comparison apples-to-apples regardless of timezone or time of day.

## Testing

- Verified with a Node script that an item with `next_due_date` set to today is now correctly included in "Due This Week" (previously excluded for UTC+ timezones).
- Confirmed no change in behavior for items due on other days within the week.
- No backend or data model changes - frontend-only fix.