### PR TITLE
fix: guard against zero/negative income in loan planner

### DIFF
--- a/templates/loan_planner.html
+++ b/templates/loan_planner.html
@@ -86,7 +86,7 @@ async function calcLoan(){
       showResult("Msg","⚠ Fill in all fields.");
       return;
     }
-    if (parseFloat(principal_front)<0||parseFloat(rate_front)<0||parseFloat(time_front)<0||parseFloat(income_front)<0){
+    if (parseFloat(principal_front)<0||parseFloat(rate_front)<0||parseFloat(time_front)<0||parseFloat(income_front)<=0){
       showResult("Msg","⚠ Inputs should be greater than zero.");
       return;
     }

--- a/utils/loan_planner.py
+++ b/utils/loan_planner.py
@@ -47,6 +47,8 @@ def emi_calculation(principal, rate, time, income):
   return {"EMI":emi,"Net_take_home":net}
   
 def financial_check(emi, income):
+  if income is None or income <= 0:
+    raise ValueError("Income must be greater than 0")
   ratio=(emi/income)
   percentage=(emi/income)*100
   if percentage<30:


### PR DESCRIPTION
## What this fixes

Fixes #459 

`financial_check()` in `utils/loan_planner.py` divided directly by `income` with no validation:

```python
def financial_check(emi, income):
  ratio=(emi/income)
  percentage=(emi/income)*100
  ...
```

If `income` was `0`, this raised an unhandled `ZeroDivisionError`, which `app.py`'s generic `except Exception` caught and returned to the client as the raw Python error message (`{"error": "division by zero"}`).

This was also reachable from the UI: the frontend validation in `templates/loan_planner.html` used `parseFloat(income_front) < 0`, which doesn't catch `0` - so entering `0` as income passed validation and crashed the backend.

## Changes

- `utils/loan_planner.py`: `financial_check()` now raises a clear `ValueError("Income must be greater than 0")` when income is `None` or `<= 0`, instead of letting the division crash. This is caught by the existing route-level `try/except` in `app.py`, so the client now gets a meaningful message with no other backend changes needed.
- `templates/loan_planner.html`: changed the income validation from `< 0` to `<= 0`, so `0` is now rejected client-side with the existing "Inputs should be greater than zero" message, before it even reaches the backend.

## Testing

- Verified `financial_check(emi, 0)` and `financial_check(emi, -100)` now raise a clean `ValueError` instead of `ZeroDivisionError`.
- Verified normal income values still compute correctly (no regression).
- Verified in the UI that entering `0` for income now shows the inline warning instead of submitting the form.

Minimal, backend + frontend fix - no changes to unrelated calculation logic.