### PR TITLE
ci: add Dependabot config for pip, npm, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "automated"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    reviewers:
+      - "omroy07"
+    ignore:
+      - dependency-name: "flask"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "workflows"
+      - "automated"


### PR DESCRIPTION
## Summary

Adds Dependabot configuration to automate dependency updates across the
three ecosystems used by the project.

## Changes

| File | Δ |
|------|---|
| `.github/dependabot.yml` | +40 (new file) |

### Schedule

| Ecosystem | Frequency | Reviewer |
|-----------|-----------|----------|
| pip (requirements.txt) | weekly | omroy07 |
| npm (package.json) | weekly | omroy07 |
| GitHub Actions | monthly | — |

Closes #439 