### PR TITLE
style: increase font size of "Smart" on dashboard page-title

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div id="dashboard" class="page active">
-  <div class="page-title">Smart <span>Dashboard</span></div>
+  <div class="page-title"><span style="font-size: 1.5em; font-weight: bold;">Smart</span> <span>Dashboard</span></div>
   <div class="dashboard-header">
     <div>
       <h2>AI Financial Advisor</h2>


### PR DESCRIPTION
### 📝 Description
This PR addresses the UI layout issue where the word **"Smart"** in the dashboard page title was looking too small or not properly highlighted. 

An inline style (`font-size: 1.5em; font-weight: bold;`) has been applied directly to the `<span>` wrapping "Smart" within `templates/dashboard.html` to improve visual hierarchy and readability on the frontend.

### 🛠️ Changes Made
- Updated `templates/dashboard.html` (Line 7) to wrap "Smart" in a styled span.
- Boosted the font size and applied a bold weight to make it stand out alongside "Dashboard".

### 🚀 How to Test
1. Switch to the `fix-font-size` branch.
2. Run the application locally.
3. Verify that the "Smart" text on the main Dashboard heading appears visibly larger and distinct.

closes #455