### PR TITLE
Marginal rebate in new tax regime

### DIFF
--- a/utils/tax.py
+++ b/utils/tax.py
@@ -69,6 +69,11 @@ def calculate_tax(income, deduction_80c=0.0, deduction_80d=0.0, deduction_hra=0.
     # Rebate under Sec 87A for New Regime:
     if taxable_new <= 700000:
         tax_new = 0.0
+    # marginal relief
+    else:
+        diff_amt=taxable_new-700000
+        if diff_amt<=tax_new:
+            tax_new=diff_amt
         
     cess_new = tax_new * 0.04
     total_new = round(tax_new + cess_new, 2)


### PR DESCRIPTION
Closes issue #240 
What was changed?
The pr resolves the issue and applied the marginal relief under new tax regime
Why was it changed?
Earlier the calculation did not take marginal relief into consideration. As a result, for a small bump, the rise in the tax was too much.
Testing:
The code was tested in the local terminal.
<img width="2560" height="1600" alt="Screenshot_2026-07-03-15-50-50-731_com android chrome" src="https://github.com/user-attachments/assets/f4024bc1-93e2-44de-8ad2-eb721e5c9514" />
