### PR TITLE
fix: derive Loan_Interest from EMI instead of compound interest (#460)

### DIFF
--- a/utils/loan_planner.py
+++ b/utils/loan_planner.py
@@ -6,9 +6,9 @@ import json
 # Load environment variables
 load_dotenv()
 def data_input(principal, rate, time, income):
-  loan_calc=compound_interest_calculation(principal, rate, time)
   emi_calc=emi_calculation(principal, rate, time, income)
   emi=emi_calc.get("EMI",0)
+  loan_calc=loan_totals_from_emi(principal, emi, time)
   check=financial_check(emi, income)
   metrics={"Loan_Amount":loan_calc.get("Amount",0),
           "Loan_Interest":loan_calc.get("Interest",0),
@@ -28,10 +28,10 @@ def data_input(principal, rate, time, income):
           "Advice": advice
   }
 
-def compound_interest_calculation(principal, rate, time):#rate per annum, time in years, amount in rupees
-  amt=principal*((1+(rate/100))**time)
-  interest=amt-principal
-  return {"Amount":amt,"Interest":interest}
+def loan_totals_from_emi(principal, emi, time):#derives amortization-consistent totals from the EMI, time in years
+  total_paid=emi*time*12
+  total_interest=total_paid-principal
+  return {"Amount":total_paid,"Interest":total_interest}
 
 def emi_calculation(principal, rate, time, income):
   m_rate=rate/12


### PR DESCRIPTION
Fixes #460 
 `utils/loan_planner.py` computed `Loan_Amount`/`Loan_Interest` using
`compound_interest_calculation()`, which applies annual compound interest to the
full, undiminished principal for the entire loan term. This models a borrower
who makes zero payments until maturity, which is inconsistent with the EMI
figure shown in the same response (where principal amortizes down monthly).

## Fix
- Removed `compound_interest_calculation()`.
- Added `loan_totals_from_emi(principal, emi, time)`, which derives
  `Loan_Amount` and `Loan_Interest` directly from the EMI:
  `total_paid = emi * time * 12`, `total_interest = total_paid - principal`.
- Reordered `data_input()` so EMI is computed first, then fed into
  `loan_totals_from_emi()`, keeping `EMI`, `Loan_Amount`, and `Loan_Interest`
  consistent with the same amortization schedule.
- No changes needed in `app.py` or `templates/loan_planner.html` — they only
  consume the `Loan_Amount`/`Loan_Interest`/`EMI` keys, which are unchanged.
  This also means `financial_advice()`'s AI prompt now receives correct
  metrics.

## Verification
For principal=₹10,00,000, rate=10%, time=20 years (as in the issue):

| Metric | Before | After |
|---|---|---|
| EMI | ₹9,650.22 | ₹9,650.22 |
| Loan_Interest | ₹57,27,500 | ₹13,16,051.95 |

Matches the expected EMI-implied interest from the bug report.
