### PR TITLE
Fix: Tax-loss harvesting caps losses at wrong-currency hardcoded IRS limit (#488)

### DIFF
--- a/utils/auto_rebalancer.py
+++ b/utils/auto_rebalancer.py
@@ -215,8 +215,8 @@ class AutoRebalancer:
                     'loss': round(abs(pnl), 2),
                     'invested': round(invested, 2),
                     'current': round(current, 2),
-                    'harvestable_loss': min(abs(pnl), 3000),  # IRS limit
-                    'suggestion': f'Consider selling {h["symbol"]} to realize ₹{min(abs(pnl), 3000):,.2f} loss'
+                    'harvestable_loss': round(abs(pnl), 2),
+                    'suggestion': f'Consider selling {h["symbol"]} to realize ₹{abs(pnl):,.2f} loss'
                 })
         
         return sorted(opportunities, key=lambda x: x['loss'], reverse=True)


### PR DESCRIPTION
## Summary
Fixes #488  - `get_tax_harvesting_opportunities()` in
`utils/auto_rebalancer.py` capped every harvestable capital loss at a flat
`3000`, labeled "IRS limit". This app is India-focused (all amounts are in
₹/INR), but the IRS $3,000/year capital-loss deduction limit is a US rule
denominated in US Dollars. Applying it directly to ₹ amounts understated
harvestable losses by up to ~94% and mislabeled the rule entirely.

## Fix
- Removed the hardcoded `min(abs(pnl), 3000)` cap.
- `harvestable_loss` and the suggestion text now reflect the full realized
  loss (`abs(pnl)`), matching the `loss` field already shown elsewhere in
  the same dict.
- Only one consumer (`app.py`), which just forwards the dict as-is - no
  other changes needed.

## Verification
Holding with buy_price=1800, current_price=1300, quantity=100 (a ₹50,000 loss):

| Field | Before | After |
|---|---|---|
| harvestable_loss | ₹3,000 | ₹50,000 |
| suggestion | "...realize ₹3,000.00 loss" | "...realize ₹50,000.00 loss" 