### PR TITLE
docs: add ARCHITECTURE.md and SETUP.md with updated README references

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,18 +160,35 @@ pytest --cov=app tests/       # With coverage
 
 ```
 AI-Money-Mentor/
+├── app.py                 ← Flask entry point (~7000 lines)
+├── agents.py              ← Standalone CLI agents
+├── models.py              ← SQLAlchemy ORM models
+├── requirements.txt       ← Production dependencies
+├── requirements-dev.txt   ← Dev/testing dependencies
+├── pyproject.toml         ← Project metadata & pytest config
+├── .env.example           ← Environment variable template
+├── templates/             ← Jinja2 HTML (40+ pages)
 ├── static/
-│   ├── css/           ← Stylesheets
-│   ├── js/            ← JavaScript
-│   └── assets/        ← Images & icons
-├── templates/         ← Jinja2 HTML
-├── tests/
-│   └── test_tax.py    ← Pytest suite
-├── app.py             ← Flask entry point
-├── requirements.txt
-├── .env.example
-└── README.md
+│   ├── styles/            ← CSS stylesheets
+│   └── scripts/           ← JavaScript files
+├── utils/                 ← Utility modules (30+)
+│   └── config.py          ← Centralized configuration
+├── tests/                 ← Pytest suite (20+ files)
+├── docs/
+│   ├── api_spec.md        ← API specification
+│   ├── ARCHITECTURE.md    ← System architecture docs
+│   └── SETUP.md           ← Setup and configuration guide
+└── .github/               ← CI/CD workflows
 ```
+
+---
+
+## 📖 Documentation
+
+- [Architecture Overview](docs/ARCHITECTURE.md) — System design, database layout, and route inventory
+- [Setup Guide](docs/SETUP.md) — Installation, configuration, and troubleshooting
+- [API Specification](docs/api_spec.md) — Endpoint documentation
+- [Contributing Guide](CONTRIBUTING.md) — How to contribute to the project
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,113 @@
+# Architecture Overview
+
+## High-Level Design
+
+AI Money Mentor is a monolithic Flask application with embedded AI orchestration,
+serving both a server-rendered web UI and a REST API.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                      Browser                            │
+│  Jinja2 templates  ←───  static/ (CSS, JS)             │
+└────────────────────┬────────────────────────────────────┘
+                     │ HTTP
+┌────────────────────▼────────────────────────────────────┐
+│                    Flask (app.py)                        │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │  Blueprints / Route Groups                        │ │
+│  │  Auth · Dashboard · Stocks · Budget · Tax         │ │
+│  │  Chat · Agent · Insights · Reports · Settings     │ │
+│  │  Notifications · Rebalancer · FIRE Planner        │ │
+│  └────────────────────────────────────────────────────┘ │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │  AI Layer                                         │ │
+│  │  utils/multi_agent.py  ←─  keyword-based routing  │ │
+│  │  agents.py             ←─  standalone CLI          │ │
+│  │  Groq API (llama-3.1-8b-instant)                  │ │
+│  └────────────────────────────────────────────────────┘ │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │  Utilities                                        │ │
+│  │  stock.py · tax.py · budget.py · alerts.py · ... │ │
+│  └────────────────────────────────────────────────────┘ │
+└──────────┬────────────────────────────────────────┬─────┘
+           │ SQLAlchemy ORM                      │ APScheduler
+┌──────────▼──────────┐              ┌───────────▼──────────┐
+│   money_mentor.db   │              │  Background Jobs     │
+│   (Flask-SQLAlchemy)│              │  Price alerts        │
+│   tables: users,    │              │  Notifications       │
+│   transactions,     │              │  Auto-rebalancing    │
+│   budgets, alerts,  │              └──────────────────────┘
+│   portfolios...     │
+└─────────────────────┘
+           │ raw sqlite3
+┌──────────▼──────────┐
+│   database.db       │
+│   email_settings    │
+└─────────────────────┘
+```
+
+## Database
+
+Two SQLite files coexist:
+
+| File | ORM | Purpose |
+|------|-----|---------|
+| `money_mentor.db` | Flask-SQLAlchemy (models.py) | All application data |
+| `database.db` | raw sqlite3 module | Email settings only |
+
+Schema is created via `db.create_all()` at startup. No migration system exists.
+
+## AI Agent System
+
+Two separate agent pipelines:
+
+1. **Web** (`utils/multi_agent.py`): Invoked from `/agent` endpoint. Uses keyword-based
+   routing (`utils/multi_agent.route_query`) to dispatch to topic-specific agents.
+2. **CLI** (`agents.py`): Standalone command-line interface with its own Groq client.
+
+Both use Groq's `llama-3.1-8b-instant` model.
+
+## Stock Data Pipeline
+
+`utils/stock.py` provides real-time and historical data via yfinance:
+- Automatic `.NS` suffix for Indian stocks when bare symbol lookup fails
+- 10-minute in-memory cache (`STOCK_CACHE` dict)
+- Separate cache for historical data
+
+## Scheduling
+
+APScheduler handles background tasks:
+- Price alert checks
+- Notification delivery
+- Auto-rebalancing triggers
+
+## Key Design Decisions
+
+- **Monolithic architecture**: Single Flask app for simplicity
+- **Dual SQLite files**: Legacy design; email settings isolated in separate file
+- **Keyword routing not LLM routing**: `/agent` endpoint uses regex/pattern matching,
+  not an LLM, to decide which agent handles a query — faster and cheaper
+- **In-memory caching**: Stock data cached in process memory for 10 minutes (no Redis)
+- **No migration framework**: Schema resets on deploy unless data is manually preserved
+
+## Route Inventory
+
+The `app.py` file defines approximately 90+ routes covering:
+
+- Authentication (login, register, logout, profile)
+- Dashboard & overview
+- Stock tracking & watchlists
+- Budget management
+- Tax computation & filing
+- AI chat & agent
+- Portfolio management
+- Financial reports (PDF export)
+- Transaction ledger
+- Notifications & alerts
+- Portfolio rebalancing
+- FIRE (Financial Independence) planning
+- Settings & account management
+- Couple finance features
+- Bank integration (UPI, statements)
+- MFA (multi-factor authentication)
+- SIP (Systematic Investment Plan) tracking

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,92 @@
+# Setup Guide
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js 18+ (for commit hooks only)
+- Groq API key (free tier available at https://console.groq.com)
+
+## Quick Start
+
+```shell
+# 1. Clone and enter the project
+git clone https://github.com/omroy07/AI-Money-Mentor.git
+cd AI-Money-Mentor
+
+# 2. Create virtual environment
+python -m venv venv
+source venv/bin/activate  # Linux/macOS
+# or: venv\Scripts\activate  # Windows
+
+# 3. Install dependencies
+pip install -r requirements.txt
+
+# 4. Configure environment
+cp .env.example .env
+# Edit .env and set GROQ_API_KEY=<your_key>
+
+# 5. Run the app
+python app.py
+# Server starts at http://localhost:5000
+```
+
+## Development Setup
+
+```shell
+# Install dev dependencies
+pip install -r requirements.txt -r requirements-dev.txt
+
+# Install git hooks
+npm install
+
+# Run tests
+pytest tests/ -v
+
+# Run a single test file
+pytest tests/test_tax.py -v
+```
+
+## Configuration
+
+All configuration is in `.env`:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GROQ_API_KEY` | Yes | — | API key for Groq LLM |
+| `SECRET_KEY` | No | auto-generated | Flask session key |
+| `DATABASE_URL` | No | sqlite:///money_mentor.db | Primary database |
+| `MAIL_SERVER` | No | localhost | SMTP server |
+| `MAIL_PORT` | No | 587 | SMTP port |
+| `MAIL_USE_TLS` | No | True | SMTP TLS |
+| `MAIL_USERNAME` | No | — | SMTP user |
+| `MAIL_PASSWORD` | No | — | SMTP password |
+
+## Production Deployment
+
+The app uses Flask's built-in development server. For production,
+use a WSGI server like Gunicorn or Waitress:
+
+```shell
+pip install gunicorn
+gunicorn -w 4 -b 0.0.0.0:5000 app:app
+```
+
+Or with eventlet for WebSocket support:
+
+```shell
+pip install eventlet
+python app.py --production
+```
+
+> **Note**: SQLite is not suitable for production workloads.
+> Consider migrating to PostgreSQL by setting `DATABASE_URL`.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| App exits immediately | Missing `GROQ_API_KEY` | Set it in `.env` |
+| Stock data fails | Unknown ticker | The app auto-tries `.NS` suffix for Indian stocks |
+| Login not working | Secret key changed | Delete the `.env` `SECRET_KEY` line to regenerate |
+| Tests fail | Missing test deps | Run `pip install -r requirements-dev.txt` |
+| CSS not loading | Static files cached | Hard refresh (Ctrl+Shift+R) |


### PR DESCRIPTION
## Summary

Adds two new documentation files to help contributors understand the
system and get started quickly.

## Changes

| File | Δ |
|------|---|
| `docs/ARCHITECTURE.md` | +113 (new) |
| `docs/SETUP.md` | +92 (new) |
| `README.md` | +27/−10 |

### ARCHITECTURE.md sections

- ASCII system diagram
- Dual-SQLite database design
- AI agent pipelines (web + CLI)
- Stock data pipeline with caching
- Route inventory (~90+ routes)

### SETUP.md sections

- Prerequisites and quick start
- Development setup with test commands
- Environment variable reference table
- Production deployment notes
- Troubleshooting table

Closes #451