### PR TITLE
Fix: CoupleFinanceManager.create_invitation() crashes with NameError (#500)

### DIFF
--- a/utils/couple_finance.py
+++ b/utils/couple_finance.py
@@ -70,11 +70,13 @@ class CoupleFinanceManager:
         db.session.commit()
         
         # Create alert for partner
+        inviter = User.query.get(user1_id)
+        inviter_name = inviter.username if inviter else "a user"
         alert = CoupleAlert(
             couple_id=couple.id,
             user_id=partner.id,
             type='INVITATION',
-            message=f'You have been invited to join a couple by {current_user.username}'
+            message=f'You have been invited to join a couple by {inviter_name}'
         )
         db.session.add(alert)
         db.session.commit()


### PR DESCRIPTION
## Summary
Fixes #500  - `create_invitation()` in `utils/couple_finance.py`
referenced `current_user` to build the partner's invitation alert message,
but `current_user` is never imported in this module (no
`from flask_login import current_user`) and isn't passed as a parameter.
Every call raised `NameError: name 'current_user' is not defined` after
the Couple row was already committed, so invitations were created but the
partner never received their alert - every "invite partner" action failed.

## Fix
- Look up the inviter via `User.query.get(user1_id)` (the ID is already
  passed into the function) instead of the undefined `current_user`.
- Falls back to `"a user"` if the lookup somehow returns nothing, so the
  alert is never blocked by a missing name.

## Verification
Ran `create_invitation()` end-to-end (with DB-facing calls mocked) and
confirmed:
- No `NameError` is raised.
- The alert message correctly resolves to the inviter's real username,
  e.g. `"You have been invited to join a couple by alice"`.
