### PR TITLE
feat: add standardized issue and pull request templates closes #97

### DIFF
--- a/.github/Issues_Template/bug_report.md
+++ b/.github/Issues_Template/bug_report.md
@@ -1,0 +1,30 @@
+---
+name:  Bug Report
+about: Report a bug to help improve AI-Money-Mentor
+title: '[BUG]: '
+labels: ['bug', 'needs-triage']
+assignees: ''
+---
+
+###  Description
+A clear and concise description of what the bug is.
+
+###  Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+###  Expected Behavior
+A clear and concise description of what you expected to happen.
+
+###  Environment Details
+* **OS:** [e.g. iOS, Android, Windows, macOS]
+* **Browser / Runtime:** [e.g. Chrome, Node.js version]
+* **Project Version:** [e.g. v1.0.0]
+
+###  Screenshots / Logs
+If applicable, add screenshots, video recordings, or stack trace logs to help explain your problem.
+
+###  Additional Context
+Add any other context about the problem here.

--- a/.github/Issues_Template/feature_request.md
+++ b/.github/Issues_Template/feature_request.md
@@ -1,0 +1,19 @@
+---
+name:  Feature Request
+about: Propose a new idea or enhancement for AI-Money-Mentor
+title: '[FEATURE]: '
+labels: ['enhancement']
+assignees: ''
+---
+
+###  Is your feature request related to a problem?
+A clear and concise description of what the problem is. (e.g. I'm always frustrated when...)
+
+###  Proposed Solution
+A clear and concise description of what you want to happen and how it fixes the problem.
+
+###  Alternatives Considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+###  Additional Context
+Add any other context or mockups about the feature request here.

--- a/.github/PR_Template.md
+++ b/.github/PR_Template.md
@@ -1,0 +1,21 @@
+###  Description
+Please include a summary of the change, which issue is fixed, and relevant motivation/context.
+
+Fixes # (issue number)
+
+###  Type of Change
+Check the options that apply to this PR:
+- [ ]  Bug fix (non-breaking change which fixes an issue)
+- [ ]  New feature (non-breaking change which adds functionality)
+- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ]  Documentation update
+
+###  Checklist
+- [ ] My code follows the code style guidelines of this project.
+- [ ] I have performed a self-review of my own code.
+- [ ] I have commented on my code, particularly in hard-to-understand areas.
+- [ ] My changes generate no new warnings or console errors.
+- [ ] I have verified my changes on local devices / environments.
+
+###  Visual Evidence (If Applicable)
+Please provide screenshots or recordings showing the before/after behavior of your changes.


### PR DESCRIPTION

_Added standardized Markdown templates to enforce structured context upfront:_
- Created `.github/ISSUE_TEMPLATE/bug_report.md` for consistent bug reporting.
- Created `.github/ISSUE_TEMPLATE/feature_request.md` for feature suggestions.
- Created `.github/PULL_REQUEST_TEMPLATE.md` to establish a default PR review checklist.

Closes #97
