### PR TITLE
fix: invert weight calculation in allocate_funds() to match priority convention

### DIFF
--- a/utils/goal_investment_planner.py
+++ b/utils/goal_investment_planner.py
@@ -144,15 +144,22 @@ class GoalInvestmentPlanner:
         if not goals:
             return {'success': False, 'error': 'No active goals found'}
         
-        # Calculate total priority weight
-        total_priority = sum(g.priority for g in goals)
-        if total_priority == 0:
-            total_priority = 1
+      # Calculate total priority weight. Goals use a 1-5 scale where 1 is
+        # the highest priority (see create_goal()'s default and
+        # get_recommendations_ai()'s "Priority: {goal.priority}/5" label), so
+        # we invert priority here to give lower-numbered (higher-priority)
+        # goals a bigger weight. This keeps weight consistent with
+        # adjusted_amount below, which already treats priority=1 as most
+        # urgent.
+        total_inverted_priority = sum(6 - g.priority for g in goals)
+        if total_inverted_priority == 0:
+            total_inverted_priority = 1
         
         # Calculate recommended allocation
         allocations = {}
         for goal in goals:
-            weight = goal.priority / total_priority
+            inverted_priority = 6 - goal.priority  # 1 -> 5, 5 -> 1 on a 1-5 scale
+            weight = inverted_priority / total_inverted_priority
             monthly_recommended = goal.calculate_monthly_required()
             
             # Adjust based on priority


### PR DESCRIPTION
Fixes #534 .
utils/goal_investment_planner.py's allocate_funds() returned weight and recommended_monthly using opposite conventions for what a goal's priority number means. adjusted_amount, create_goal()'s default, and get_recommendations_ai()'s priority label all treat priority=1 as the highest priority, but weight was calculated as goal.priority divided by total_priority, which gave higher-numbered (lower-priority) goals more weight.
The fix inverts the priority before computing weight, using 6 minus priority on the 1 to 5 scale, so weight and recommended_monthly now agree on which goal matters most.
Verified with the issue's own example: two goals with the same monthly_required, one priority 1 and one priority 5. Before the fix, weight ranked them 16.7 percent versus 83.3 percent while recommended_monthly ranked them 14000 rupees versus 10000 rupees, opposite order. After the fix, weight is 83.33 percent versus 16.67 percent and recommended_monthly is 14000 rupees versus 10000 rupees, same order, both pointing to priority 1 as the goal that should get more funding.
No other files reference total_priority or read the weight field, so this change is self contained.