### PR TITLE
fix: compute true running balance_after in get_transaction_history()

### DIFF
--- a/utils/ledger.py
+++ b/utils/ledger.py
@@ -289,13 +289,27 @@ class LedgerSystem:
         if not account:
             raise ValueError(f"Account {account_id} not found")
         
-        # Get all ledger entries for this account
+      # Fetch all entries oldest-first so we can replay them into a running
+        # balance. balance_after must reflect the account's balance
+        # immediately after that specific entry, not the account's current
+        # (present-day) balance, so we can't just read account.balance here.
         entries = LedgerEntry.query.filter_by(account_id=account_id).order_by(
-            LedgerEntry.timestamp.desc()
-        ).limit(limit).all()
+            LedgerEntry.timestamp.asc()
+        ).all()
+        
+        running_balance = 0.0
+        history_with_balance = []
+        for entry in entries:
+            delta = float(entry.amount) if entry.entry_type == 'CREDIT' else -float(entry.amount)
+            running_balance += delta
+            history_with_balance.append((entry, running_balance))
+        
+        # Display most-recent-first, then apply the limit
+        history_with_balance.reverse()
+        history_with_balance = history_with_balance[:limit]
         
         result = []
-        for entry in entries:
+        for entry, balance_after in history_with_balance:
             transaction = Transaction.query.get(entry.transaction_id)
             if transaction:
                 result.append({
@@ -307,7 +321,7 @@ class LedgerSystem:
                     'description': entry.description or transaction.description,
                     'timestamp': entry.timestamp.isoformat(),
                     'status': transaction.status,
-                    'balance_after': float(account.balance)  # Approximate
+                    'balance_after': round(balance_after, 2)
                 })
         
         return result


### PR DESCRIPTION
Fixes #535 .
utils/ledger.py's get_transaction_history() set balance_after to the account's live current balance for every entry in the returned history. account.balance was fetched once at the top of the function and never changed across the loop, so every transaction in a multi-transaction history reported the identical present-day balance instead of the balance that actually existed right after that specific transaction.
The fix fetches ledger entries oldest first and replays them into a running balance, adding the amount for CREDIT entries and subtracting it for DEBIT entries, which matches the sign convention already used by reconcile_account() elsewhere in the same file. The results are then reversed back to most-recent-first for display and the limit is applied after replaying, not before, so the running balance is always computed from the full history rather than just the most recent slice.
Verified with the issue's own example: a deposit of 1000, a withdrawal of 500, and a deposit of 2000, ending at a current balance of 2500. Before the fix, every entry returned balance_after as 2500. After the fix, the entries return 2500, 500, and 1000 in most-recent-first order, matching the account's true balance trajectory.
app.py calls get_transaction_history() in four places, all of which just pass account_id and limit and read the returned list. The return shape is unchanged, so no caller needs updating.