### PR TITLE
fix: add rate limiting to /register endpoint (#587)

### DIFF
--- a/app.py
+++ b/app.py
@@ -662,6 +662,7 @@ def validate_password_strength(password):
 
 # ---------------- HOME ----------------
 @app.route("/register", methods=["POST"])
+@limiter.limit("5 per minute")
 def register():
     data = request.json or {}
     username = data.get("username")


### PR DESCRIPTION
## Summary
Fixes #587

Adds `@limiter.limit('5 per minute')` to the `/register` endpoint to prevent DoS and account spam attacks.

## Changes
- Added rate limiting decorator to `/register` route in `app.py` (line 665)
- Matches the existing rate limit pattern used on `/login` (5 requests per minute per IP)

## Why This Matters
Without rate limiting, attackers can:
- Spam the registration endpoint with thousands of requests
- Cause heavy server load via bcrypt password hashing (expensive operation)
- Bloat the database with fake accounts
- Effectively perform a Denial of Service attack

## Testing
- Verified the `limiter` instance is already initialized at line 76 with `get_remote_address` as the key function
- The decorator follows the exact same pattern as `/login` at line 690