### PR TITLE
fix: add MAX_CONTENT_LENGTH to prevent unrestricted file uploads (#585)

### DIFF
--- a/app.py
+++ b/app.py
@@ -197,6 +197,11 @@ mail = Mail(app)
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///money_mentor.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
+# ---------------- UPLOAD SIZE LIMIT ----------------
+# Reject request payloads larger than 16 MB to prevent memory exhaustion
+# and Denial of Service via oversized file uploads.
+app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024  # 16 MB
+
 # ---------------- SECRET KEY ----------------
 # SECRET_KEY signs session cookies. In production it MUST come from the
 # environment - a hardcoded fallback would let anyone with the public repo


### PR DESCRIPTION
## Summary
Fixes #585

Adds \\MAX_CONTENT_LENGTH = 16 MB\\ to the Flask app configuration to reject oversized request payloads.

## Changes
- Added \\pp.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024\\ after the database config section in \\pp.py\\

## Why This Matters
Without this setting, endpoints like \\/upload\\ and \\/api/parse-document\\ accept arbitrarily large files, which can cause memory exhaustion (OOM), disk space exhaustion, and Denial of Service.

Flask automatically returns a 413 (Request Entity Too Large) response when \\MAX_CONTENT_LENGTH\\ is set and the payload exceeds the limit.