### PR TITLE
fix: remove duplicate Flask app re-initialization (#584)

### DIFF
--- a/app.py
+++ b/app.py
@@ -179,9 +179,10 @@ from utils.rag_system import RAGSystem
 from utils.fx import convert_to_base, get_rate
 from utils.loan_planner import data_input
 
-
-app = Flask(__name__)
-
+# Continue configuring the same app instance initialized above (line 64).
+# NOTE: A duplicate `app = Flask(__name__)` was previously here, which
+# silently detached SocketIO (line 67) and the rate Limiter (line 76)
+# from the active app context. Removed to fix #584.
 
 # ---------------- EMAIL CONFIG ----------------
 app.config['MAIL_SERVER'] = 'smtp.gmail.com'


### PR DESCRIPTION
## Summary
Fixes #584

Removed the duplicate \\pp = Flask(__name__)\\ at line 183 that was silently detaching SocketIO and the rate Limiter.

## Root Cause
The Flask app was initialized at line 64, but then **re-initialized** at line 183 after all the imports. This created a NEW Flask instance, meaning:
- SocketIO (bound at line 67) was attached to the OLD instance
- Rate Limiter (bound at line 76) was attached to the OLD instance
- All subsequent config and routes operated on the NEW instance

## Fix
Removed the duplicate initialization and added a comment explaining the app instance continues from line 64.

## Impact
- SocketIO and Limiter now correctly operate on the same Flask app instance
- No behavioral changes to routes or config