### PR TITLE
refactor: replace raw SQLite connections with SQLAlchemy ORM

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ from models import (
     BankConnection, BankTransaction, FraudAlert, Notification,
     NotificationPreference, InvestmentGoal, GoalAllocation,
     GoalContribution, GoalRecommendation, Couple,
-    CoupleSubscription, User,
+    CoupleSubscription, User, UserSettings
 )
 
 
@@ -262,26 +262,11 @@ def load_user(user_id):
 
 # ---------------- EMAIL DB ----------------
 def init_email_db():
-    conn = sqlite3.connect('database.db')
-    c = conn.cursor()
-    c.execute('''
-        CREATE TABLE IF NOT EXISTS user_settings (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            email VARCHAR(120) UNIQUE,
-            weekly_email_enabled BOOLEAN DEFAULT 1,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-        )
-    ''')
-    conn.commit()
-    conn.close()
+    pass
 
 def get_user_email_settings():
-    conn = sqlite3.connect('database.db')
-    c = conn.cursor()
-    c.execute('SELECT email FROM user_settings WHERE weekly_email_enabled = 1')
-    users = c.fetchall()
-    conn.close()
-    return [user[0] for user in users]
+    users = UserSettings.query.filter_by(weekly_email_enabled=True).all()
+    return [user.email for user in users]
 
 init_email_db()
 
@@ -3530,11 +3515,15 @@ def update_email():
     enabled = data.get('enabled', True)
     if not email:
         return jsonify({'error': 'Email is required'}), 400
-    conn = sqlite3.connect('database.db')
-    c = conn.cursor()
-    c.execute('INSERT OR REPLACE INTO user_settings (email, weekly_email_enabled) VALUES (?, ?)', (email, 1 if enabled else 0))
-    conn.commit()
-    conn.close()
+    
+    setting = UserSettings.query.filter_by(email=email).first()
+    if setting:
+        setting.weekly_email_enabled = enabled
+    else:
+        setting = UserSettings(email=email, weekly_email_enabled=enabled)
+        db.session.add(setting)
+        
+    db.session.commit()
     return jsonify({'success': True, 'message': 'Settings updated successfully'})
 
 @app.route('/api/unsubscribe', methods=['POST'])
@@ -3543,11 +3532,12 @@ def unsubscribe():
     email = data.get('email')
     if not email:
         return jsonify({'error': 'Email is required'}), 400
-    conn = sqlite3.connect('database.db')
-    c = conn.cursor()
-    c.execute('UPDATE user_settings SET weekly_email_enabled = 0 WHERE email = ?', (email,))
-    conn.commit()
-    conn.close()
+        
+    setting = UserSettings.query.filter_by(email=email).first()
+    if setting:
+        setting.weekly_email_enabled = False
+        db.session.commit()
+        
     return jsonify({'success': True, 'message': 'Unsubscribed successfully'})
 
 # ---------------- TEST EMAIL ROUTES ----------------

--- a/models.py
+++ b/models.py
@@ -1663,4 +1663,10 @@ class GroupSettlement(db.Model):
             'settled_at': self.settled_at.isoformat() if self.settled_at else None,
         }
 
-
+class UserSettings(db.Model):
+    __tablename__ = 'user_settings'
+    
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    weekly_email_enabled = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)


### PR DESCRIPTION
﻿## 🚀 Program (ELUSOC)

This PR is part of ELUSOC 2026.

## ✨ PR Description
Refactored the application to replace raw sqlite3.connect calls with SQLAlchemy ORM. Introduced the UserSettings model for tracking weekly email preferences.

## 🔗 Related Issue
Closes #597

## 🤔 Problem It Solves
Bypassing SQLAlchemy for certain queries bypassed ORM advantages such as connection pooling, query optimization, and consistent migration tracking. Centralizing DB operations in SQLAlchemy ORM maintains architecture consistency and security against SQL injections.

## ✅ Acceptance Criteria
- [x] Removed sqlite3.connect from pp.py.
- [x] Created UserSettings model in models.py.
- [x] Refactored init_email_db, get_user_email_settings, update_email, and unsubscribe to use SQLAlchemy.
- [x] CI Tests pass locally.

## 🌱 Contributor Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally
- [x] I have added comments to my code where necessary
- [x] My code follows the project's style guidelines
