### PR TITLE
fix: add missing email validation to registration and invite endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -648,6 +648,9 @@ def register():
     if not username or not password or not email:
         return jsonify({"error": "Username, email, and password are required."}), 400
 
+    if not re.match(r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$', email):
+        return jsonify({"error": "Invalid email address format."}), 400
+
     password_error = validate_password_strength(password)
     if password_error:
         return jsonify({"error": password_error}), 400
@@ -1937,6 +1940,8 @@ def couple_invite():
         email = data.get('email')
         if not email:
             return jsonify({'error': 'Email is required'}), 400
+        if not re.match(r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$', email):
+            return jsonify({'error': 'Invalid email address format.'}), 400
         result = couple_manager.create_invitation(current_user.id, email)
         return jsonify(result)
     except Exception as e:


### PR DESCRIPTION
﻿## 🚀 Program (ELUSOC)

This PR is part of ELUSOC 2026.

## ✨ PR Description
Added email validation regex to the /register and /api/couple/invite endpoints to ensure only valid email formats are accepted during user registration and invitations.

## 🔗 Related Issue
Closes #596

## 🤔 Problem It Solves
Prevents users from registering with invalid email addresses (e.g. 	est@test) which can lead to errors when the system tries to send them notifications or reports. It also secures the system against bad inputs.

## ✅ Acceptance Criteria
- [x] Added e.match validation to /register.
- [x] Added e.match validation to /api/couple/invite.
- [x] Returns 400 with a clear error message on invalid emails.
- [x] CI Tests pass locally.

## 🌱 Contributor Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally
- [x] I have added comments to my code where necessary
- [x] My code follows the project's style guidelines
