### PR TITLE
feat: add centralized 401 handler and matching error page

### DIFF
--- a/app.py
+++ b/app.py
@@ -4308,6 +4308,13 @@ def forbidden(error):
         return render_template("403.html", active_page=None), 403
     return jsonify({"error": "Forbidden", "message": "You do not have permission to access this resource.", "status_code": 403}), 403
 
+@app.errorhandler(401)
+def unauthorized(error):
+    logger.info("401 Unauthorized: %s %s", request.method, request.path)
+    if request.accept_mimetypes.accept_html and not request.accept_mimetypes.accept_json:
+        return render_template("401.html", active_page=None), 401
+    return jsonify({"error": "Unauthorized", "message": "You must be signed in to access this resource.", "status_code": 401}), 401
+
 @app.errorhandler(404)
 def not_found(error):
     logger.info("404 Not Found: %s %s", request.method, request.path)

--- a/templates/401.html
+++ b/templates/401.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+
+{% block title %}401 — Unauthorized | AI Money Mentor{% endblock %}
+
+{% block content %}
+<div class="error-page">
+    <div class="error-card">
+        <div class="error-code">401</div>
+        <div class="error-icon">🔑</div>
+        <h1 class="error-title">Sign In Required</h1>
+        <p class="error-message">
+            You need to be signed in to access this resource.
+        </p>
+        <div class="error-actions">
+            <a href="{{ url_for('home') }}" class="btn-primary">
+                🏠 Back to Dashboard
+            </a>
+        </div>
+    </div>
+</div>
+
+<style>
+.error-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 70vh;
+    padding: 2rem;
+}
+.error-card {
+    background: var(--card-bg, #1e1e2e);
+    border: 1px solid var(--border, rgba(255,255,255,0.08));
+    border-radius: 1.5rem;
+    padding: 3rem 4rem;
+    text-align: center;
+    max-width: 480px;
+    width: 100%;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+}
+.error-code {
+    font-size: 6rem;
+    font-weight: 800;
+    line-height: 1;
+    background: linear-gradient(135deg, #6c63ff, #48cfad);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 0.5rem;
+}
+.error-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+.error-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-primary, #f8f8f8);
+    margin: 0 0 0.75rem;
+}
+.error-message {
+    color: var(--text-secondary, #a0a0b0);
+    font-size: 1rem;
+    margin-bottom: 2rem;
+    line-height: 1.6;
+}
+.btn-primary {
+    display: inline-block;
+    padding: 0.75rem 2rem;
+    background: linear-gradient(135deg, #6c63ff, #48cfad);
+    color: #fff;
+    border-radius: 0.75rem;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.95rem;
+    transition: opacity 0.2s, transform 0.2s;
+}
+.btn-primary:hover {
+    opacity: 0.9;
+    transform: translateY(-2px);
+}
+</style>
+{% endblock %}


### PR DESCRIPTION
Fixes the gap in #575.

The application already has most of what this issue asks for: centralized handlers for 400, 403, 404, 405, 429, and 500, each returning structured JSON with error, message, and status_code fields, custom branded templates for 403, 404, and 500, debug mode gated behind an environment variable so it defaults off, and logging via logger.warning, logger.info, and logger.exception on every handler without exposing stack traces in the response body.

The one real gap is 401. LoginManager is initialized without a login_view, which means every route decorated with login_required falls back to Flask's default plain text 401 response when there is no errorhandler registered for it, both for page requests and for API requests. That is inconsistent with every other error code in the app.

This adds templates/401.html, styled identically to the existing 403, 404, and 500 pages, and an errorhandler for 401 that follows the same pattern as the existing 403 handler: it renders the custom page for browser requests and returns the same structured JSON shape used by the other handlers for API requests.

Verified with a standalone Flask app reproducing the same login_required and errorhandler setup: a request to a protected route with no session now returns the custom page when the Accept header is text/html, and returns the structured JSON error object when the Accept header is application/json.

The existing manual 401 response in the login route itself, used for a wrong username or password, was left unchanged since it is a normal expected authentication failure with its own specific message rather than an unhandled access error, and changing it risks breaking frontend code that depends on its current response shape.