### PR TITLE
fix: repair broken duplicate _get_status() causing IndentationError

### DIFF
--- a/utils/financial_ratio_analyzer.py
+++ b/utils/financial_ratio_analyzer.py
@@ -13,6 +13,9 @@ class FinancialRatioAnalyzer:
     Comprehensive Financial Ratio Analysis Engine
     """
     
+    # Ratios where a LOWER value than the benchmark is actually better
+    LOWER_IS_BETTER = {'debt_to_equity', 'debt_ratio'}
+    
     def __init__(self, financial_data: Dict):
         """
         Initialize with financial data
@@ -171,9 +174,6 @@ class FinancialRatioAnalyzer:
         
         return benchmarks.get(industry, benchmarks['general'])
     
-    def _get_status(self, value: float, benchmark: float) -> str:
-    # Ratios where a LOWER value than the benchmark is actually better
-    LOWER_IS_BETTER = {'debt_to_equity', 'debt_ratio'}
 
     def _get_status(self, value: float, benchmark: float, ratio_key: str = None) -> str:
         """Get status based on comparison with benchmark"""


### PR DESCRIPTION
Fixes the syntax error described in the issue #621 

utils/financial_ratio_analyzer.py could not be imported at all. _get_status(self, value, benchmark) at line 174 had no body, since the LOWER_IS_BETTER line right after it was flush with the def statement instead of indented into it, which raises IndentationError the moment Python tries to parse the file. A second, complete _get_status with an extra ratio_key parameter was defined immediately after the broken one.

The root problem was that LOWER_IS_BETTER was written as if it were a local variable inside that broken stub, but the working _get_status definition below it references self.LOWER_IS_BETTER, which only resolves correctly if it is a class attribute. Simply fixing the indentation in place would not have worked, since a local variable inside one method is not visible as self.something in another.

The fix moves LOWER_IS_BETTER up into the class body, right after the docstring, and removes the broken empty _get_status stub entirely, leaving only the complete definition with the ratio_key parameter that the caller at line 109 already passes.

Verified the module now imports and compiles cleanly, and that flake8 with select=E9,F63,F7,F82 passes with no errors. Also re-verified the original leverage-ratio behavior this class attribute exists for: an overleveraged company with debt_to_equity=3.0 against a benchmark of 1.5 now correctly scores poor, a low-leverage company with debt_to_equity=0.5 against the same benchmark scores excellent, and an unrelated higher-is-better ratio like roe is unaffected by the change.