### PR TITLE
fix: add missing Tutorial, Quiz, Question, UserTutorialProgress, UserChallenge models

### DIFF
--- a/models.py
+++ b/models.py
@@ -1459,7 +1459,63 @@ class InsurancePolicy(db.Model):
             "expiry_date": self.expiry_date,
             "created_at": self.created_at.isoformat() if self.created_at else None
         }
+class Tutorial(db.Model):
+    __tablename__ = 'tutorials'
 
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.String(500))
+    content = db.Column(db.Text, nullable=False)
+    category = db.Column(db.String(100))
+    points_reward = db.Column(db.Integer, default=0, nullable=False)
+
+
+class Quiz(db.Model):
+    __tablename__ = 'quizzes'
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.String(500))
+    points_reward = db.Column(db.Integer, default=0, nullable=False)
+
+    questions = db.relationship('Question', backref='quiz', lazy=True, cascade='all, delete-orphan')
+
+
+class Question(db.Model):
+    __tablename__ = 'questions'
+
+    id = db.Column(db.Integer, primary_key=True)
+    quiz_id = db.Column(db.Integer, db.ForeignKey('quizzes.id'), nullable=False)
+    question_text = db.Column(db.Text, nullable=False)
+    option_a = db.Column(db.String(255), nullable=False)
+    option_b = db.Column(db.String(255), nullable=False)
+    option_c = db.Column(db.String(255), nullable=False)
+    option_d = db.Column(db.String(255), nullable=False)
+    correct_option = db.Column(db.String(1), nullable=False)  # 'A', 'B', 'C', or 'D'
+    explanation = db.Column(db.Text)
+
+
+class UserTutorialProgress(db.Model):
+    __tablename__ = 'user_tutorial_progress'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user = db.relationship('User', backref=db.backref('tutorial_progress', lazy=True))
+    tutorial_id = db.Column(db.Integer, db.ForeignKey('tutorials.id'), nullable=False)
+    tutorial = db.relationship('Tutorial')
+    completed = db.Column(db.Boolean, default=False, nullable=False)
+    completed_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class UserChallenge(db.Model):
+    __tablename__ = 'user_challenges'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user = db.relationship('User', backref=db.backref('challenges', lazy=True))
+    challenge_key = db.Column(db.String(100), nullable=False)
+    completed = db.Column(db.Boolean, default=True, nullable=False)
+    completed_at = db.Column(db.DateTime, default=datetime.utcnow)
 class UserQuizAttempt(db.Model):
     __tablename__ = 'user_quiz_attempts'
     


### PR DESCRIPTION
Fixes the blocking bug described in #620.

models.py's UserQuizAttempt has a foreign key to quizzes.id, and both utils/gamification.py and tests/test_education.py import Tutorial, Quiz, Question, UserTutorialProgress, and UserChallenge from models, but none of these five model classes actually existed in the codebase. Since app.py calls db.create_all() at module import time, this raised NoReferencedTableError the moment app.py was imported, which blocked every test in the suite, not just education-related ones, since tests/conftest.py does from app import app, db at collection time.

This adds all five missing models, with fields reconstructed directly from how gamification.py's seeding function and test_education.py's assertions already use them, and following the same conventions as the existing UserQuizAttempt model for table naming, relationships, and nullability.

Verified directly against a standalone Flask app with these models registered: db.create_all() now succeeds and creates all six related tables including the full foreign key chain, and calling seed_educational_content() end to end seeds at least 4 tutorials, 4 quizzes, and 10 questions, matching test_education.py's own test_seeding assertions.

Two things worth flagging separately rather than folding into this PR. First, this fix unblocks app and test startup as the issue title describes, but test_education.py also exercises a full Education Hub feature, routes like /learn, /api/tutorials, /api/quizzes, /api/challenges, /api/achievements, plus achievement badge logic, none of which exist yet in app.py. That is a much larger feature build and deserves its own issue. Second, once tables could finally be created, a separate and previously masked bug surfaced: SharedGoal.contributions defines a backref with cascade="all, delete-orphan" that is invalid on the many-to-one side of that relationship, which SQLAlchemy only detects once it fully configures all mappers, something that never happened before because startup crashed first. That is also unrelated to this fix and worth its own issue.