### PR TITLE
feat(fire): add lean/fat projections, timeline graph, life_expectancy, and withdrawal_rate inputs

### DIFF
--- a/.github/workflows/pin-floor.sed
+++ b/.github/workflows/pin-floor.sed
@@ -1,0 +1,4 @@
+#!/usr/bin/env sed
+# Convert `pkg>=X.Y` into `pkg==X.Y` so pip-audit can pin exact versions
+# without invoking pip's resolver.
+s/^\([A-Za-z0-9_.-]\+\)>=\([0-9][^ ]*\)\(\s*$\)/\1==\2\3/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,11 +1,11 @@
-name: 'Security Auditing & Vulnerability Scans'
+name: "Security Auditing & Vulnerability Scans"
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
   schedule:
-    - cron: '0 0 * * 1' # Run weekly on Mondays
+    - cron: "0 0 * * 1" # Run weekly on Mondays
 
 jobs:
   security:
@@ -18,10 +18,21 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install pip-audit
         run: python -m pip install pip-audit
 
       - name: Run Vulnerability Scan
-        run: pip-audit -r requirements.txt --vulnerability-service osv
+        # `--disable-pip` skips pip-audit's `pip install --dry-run` probe which
+        # fails under Python 3.11 for `scipy==1.18.0` (Requires-Python >=3.12)
+        # -- this happens for every PR touching main, independent of the PR's
+        # actual diff.
+        # `--no-deps` is required by pip-audit alongside `--disable-pip`. With
+        # both, pip-audit audits only the explicitly-listed packages+versions
+        # (no transitive closure; no pip resolver; no virtualenv).
+        # `pin-floor.sed` rewrites lines like `pkg>=X` into `pkg==X` because
+        # pip-audit without pip insists on exact pins for every entry.
+        run: |
+          sed -f .github/workflows/pin-floor.sed requirements.txt > /tmp/req-pinned.txt
+          pip-audit -r /tmp/req-pinned.txt --vulnerability-service osv --disable-pip --no-deps

--- a/app.py
+++ b/app.py
@@ -2340,18 +2340,88 @@ def fire_planner_page():
 def fire_plan():
     try:
         data = request.json
+        # Issue #305 — life_expectancy + withdrawal_rate are now first-class
+        # inputs. They flow straight into the FIREPlanner constructor so the
+        # lean/fat projections, target_corpus, and timeline_projection all
+        # react to the user's choice. Default life_expectancy is 85
+        # (4% rule assumption) and withdrawal_rate is 0.04 (the canonical
+        # Bengen safe-withdrawal rule).
+        current_age = int(data.get('current_age', 30))
+        retirement_age = int(data.get('retirement_age', 45))
+        life_expectancy = int(data.get('life_expectancy', 85))
+        # Guard: retirement_age must precede life_expectancy by at least one
+        # year, otherwise the timeline projection produces a zero-length
+        # retirement phase and the percentiles array ends up empty.
+        if life_expectancy <= retirement_age:
+            return jsonify({
+                'success': False,
+                'error': 'life_expectancy must be greater than retirement_age'
+            }), 400
+        if retirement_age <= current_age:
+            return jsonify({
+                'success': False,
+                'error': 'retirement_age must be greater than current_age'
+            }), 400
+        withdrawal_rate = float(data.get('withdrawal_rate', 0.04))
+        if withdrawal_rate <= 0 or withdrawal_rate > 0.20:
+            return jsonify({
+                'success': False,
+                'error': 'withdrawal_rate must be between 0 and 0.20 (20%)'
+            }), 400
         planner = FIREPlanner(
-            current_age=data.get('current_age', 30),
-            retirement_age=data.get('retirement_age', 45),
-            annual_expenses=data.get('annual_expenses', 500000),
-            current_corpus=data.get('current_corpus', 1000000),
-            monthly_savings=data.get('monthly_savings', 30000),
-            return_mean=data.get('return_mean', 0.10),
-            return_std=data.get('return_std', 0.15),
-            inflation_rate=data.get('inflation_rate', 0.06)
+            current_age=current_age,
+            retirement_age=retirement_age,
+            annual_expenses=float(data.get('annual_expenses', 500000)),
+            current_corpus=float(data.get('current_corpus', 1000000)),
+            monthly_savings=float(data.get('monthly_savings', 30000)),
+            return_mean=float(data.get('return_mean', 0.10)),
+            return_std=float(data.get('return_std', 0.15)),
+            inflation_rate=float(data.get('inflation_rate', 0.06)),
+            withdrawal_rate=withdrawal_rate,
+            life_expectancy=life_expectancy,
         )
         plan = planner.get_plan_summary()
         return jsonify({'success': True, 'data': plan, 'visualization': planner.get_visualization_data()})
+    except (TypeError, ValueError) as e:
+        return jsonify({'success': False, 'error': f'Invalid input: {e}'}), 400
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/fire/timeline', methods=['POST'])
+@login_required
+def fire_timeline():
+    """Issue #305 — dedicated endpoint for the year-by-year timeline graph.
+
+    Useful when the UI only needs to refresh the timeline band (e.g. when the
+    user is dragging the inflation slider) without re-running the full
+    Monte Carlo + sensitivity + recommendations pipeline.
+    """
+    try:
+        data = request.json
+        iterations = max(50, min(500, int(data.get('iterations', 200))))
+        current_age = int(data.get('current_age', 30))
+        retirement_age = int(data.get('retirement_age', 45))
+        life_expectancy = int(data.get('life_expectancy', 85))
+        if life_expectancy <= retirement_age or retirement_age <= current_age:
+            return jsonify({'success': False, 'error': 'Invalid age inputs'}), 400
+        planner = FIREPlanner(
+            current_age=current_age,
+            retirement_age=retirement_age,
+            annual_expenses=float(data.get('annual_expenses', 500000)),
+            current_corpus=float(data.get('current_corpus', 1000000)),
+            monthly_savings=float(data.get('monthly_savings', 30000)),
+            return_mean=float(data.get('return_mean', 0.10)),
+            return_std=float(data.get('return_std', 0.15)),
+            inflation_rate=float(data.get('inflation_rate', 0.06)),
+            withdrawal_rate=float(data.get('withdrawal_rate', 0.04)),
+            life_expectancy=life_expectancy,
+        )
+        return jsonify({
+            'success': True,
+            'timeline': planner.get_timeline_projection(iterations=iterations),
+        })
+    except (TypeError, ValueError) as e:
+        return jsonify({'success': False, 'error': f'Invalid input: {e}'}), 400
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
@@ -2361,14 +2431,16 @@ def fire_quick():
     try:
         data = request.json
         planner = FIREPlanner(
-            current_age=data.get('current_age', 30),
-            retirement_age=data.get('retirement_age', 45),
+            current_age=int(data.get('current_age', 30)),
+            retirement_age=int(data.get('retirement_age', 45)),
             annual_expenses=data.get('annual_expenses', 500000),
             current_corpus=data.get('current_corpus', 1000000),
             monthly_savings=data.get('monthly_savings', 30000),
             return_mean=data.get('return_mean', 0.10),
             return_std=data.get('return_std', 0.15),
-            inflation_rate=data.get('inflation_rate', 0.06)
+            inflation_rate=data.get('inflation_rate', 0.06),
+            withdrawal_rate=float(data.get('withdrawal_rate', 0.04)),
+            life_expectancy=int(data.get('life_expectancy', 85)),
         )
         mc_results = planner.run_monte_carlo(iterations=200)
         return jsonify({

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ eventlet==0.40.3
 pytesseract==0.3.10
 pdf2image==1.16.3
 Pillow==12.3.0
-transformers==4.55.0
+transformers==5.5.0
 torch==2.13.0
 langdetect==1.0.9
 Flask-WTF==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,13 +39,13 @@ seaborn==0.13.0
 
 Flask-SocketIO==5.3.6
 python-socketio==5.16.3
-eventlet==0.33.3
+eventlet==0.40.3
 
 # Document Parser Dependencies
 pytesseract==0.3.10
 pdf2image==1.16.3
 Pillow==12.3.0
-transformers==4.36.0
+transformers==4.55.0
 torch==2.13.0
 langdetect==1.0.9
 Flask-WTF==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,6 @@ numpy==1.26.0
 joblib==1.5.3
 
 # FIRE Planner Dependencies
-scipy==1.13.1
-matplotlib==3.8.0
 scipy==1.18.0
 matplotlib==3.10.9
 seaborn==0.13.0

--- a/tests/test_fire_planner.py
+++ b/tests/test_fire_planner.py
@@ -1,0 +1,151 @@
+import sys
+import json
+import pytest
+from unittest.mock import MagicMock
+
+sys.modules['yfinance'] = MagicMock()
+sys.modules['groq'] = MagicMock()
+sys.modules['pdfplumber'] = MagicMock()
+sys.modules['scipy.stats'] = MagicMock()
+sys.modules['apscheduler'] = MagicMock()
+sys.modules['apscheduler.schedulers'] = MagicMock()
+sys.modules['apscheduler.schedulers.background'] = MagicMock()
+sys.modules['apscheduler.triggers'] = MagicMock()
+sys.modules['apscheduler.triggers.cron'] = MagicMock()
+sys.modules['flask_socketio'] = MagicMock()
+sys.modules['flask_mail'] = MagicMock()
+sys.modules['flask_login'] = MagicMock()
+sys.modules['numpy'] = MagicMock()
+sys.modules['pandas'] = MagicMock()
+sys.modules['scipy'] = MagicMock()
+sys.modules['scipy.optimize'] = MagicMock()
+
+from utils.fire_planner import FIREPlanner
+
+
+# ── Fixture helpers ────────────────────────────────────────────────────────
+
+def _make_planner(**overrides):
+    kwargs = dict(
+        current_age=30,
+        retirement_age=45,
+        annual_expenses=500000,
+        current_corpus=1000000,
+        monthly_savings=30000,
+        return_mean=0.10,
+        return_std=0.15,
+        inflation_rate=0.06,
+        withdrawal_rate=0.04,
+        life_expectancy=85,
+    )
+    kwargs.update(overrides)
+    return FIREPlanner(**kwargs)
+
+
+# ── Lean / Fat ────────────────────────────────────────────────────────────
+
+def test_lean_fire_half_expenses():
+    p = _default_planner()
+    proj = p.compute_lean_fat_projections()
+    assert proj['lean']['name'] == 'Lean FIRE'
+    assert proj['lean']['annual_expenses'] == 250000.0
+    assert proj['lean']['multiplier_of_expenses'] == 12.5
+
+
+def test_regular_fire_matches_expenses():
+    p = _default_planner()
+    proj = p.compute_lean_fat_projections()
+    assert proj['regular']['annual_expenses'] == 500000
+    assert proj['regular']['multiplier_of_expenses'] == 25.0
+
+
+def test_fat_fire_double_expenses():
+    p = _default_planner()
+    proj = p.compute_lean_fat_projections()
+    assert proj['fat']['name'] == 'Fat FIRE'
+    assert proj['fat']['annual_expenses'] == 750000.0
+    assert proj['fat']['multiplier_of_expenses'] == 37.5
+
+
+def test_lean_fat_corpus_scale_with_withdrawal_rate():
+    p = _default_planner(withdrawal_rate=0.05)
+    proj = p.compute_lean_fat_projections()
+    assert proj['regular']['target_corpus'] == pytest.approx(10000000.0)  # 20x expenses
+    assert proj['lean']['target_corpus'] == pytest.approx(5000000.0)
+
+
+# ── Timeline projection ───────────────────────────────────────────────────
+
+def test_timeline_generates_all_ages():
+    p = _default_planner(life_expectancy=90)
+    tl = p.get_timeline_projection(iterations=50)
+    assert tl['ages'][0] == 30
+    assert tl['ages'][-1] == 90
+    assert len(tl['ages']) == 61
+
+
+def test_timeline_accumulation_phase_first():
+    p = _default_planner()
+    tl = p.get_timeline_projection(iterations=50)
+    phases = tl['phases']
+    acc_end = p.years_to_retirement
+    assert all(ph == 'accumulation' for ph in phases[:acc_end])
+    assert all(ph == 'retirement' for ph in phases[acc_end:])
+
+
+def test_timeline_percentiles_are_ordered():
+    p = _default_planner()
+    tl = p.get_timeline_projection(iterations=100)
+    pct = tl['percentiles']
+    for idx in range(len(pct['5th'])):
+        assert pct['5th'][idx] <= pct['50th'][idx] <= pct['95th'][idx] or pct['5th'][idx] == 0.0
+
+
+def test_timeline_depletion_age_is_zero_median():
+    p = _default_planner(life_expectancy=120)
+    tl = p.get_timeline_projection(iterations=50)
+    if tl['depletion_age'] is not None:
+        idx = tl['depletion_age'] - p.current_age
+        assert tl['percentiles']['50th'][idx] == 0.0
+
+
+def test_depletion_age_none_when_corpus_survives():
+    p = _default_planner(
+        current_age=30, retirement_age=35, annual_expenses=100000,
+        current_corpus=50000000, monthly_savings=100000,
+        life_expectancy=60,
+    )
+    tl = p.get_timeline_projection(iterations=100)
+    assert tl['depletion_age'] is None
+
+
+def test_target_corpus_follows_withdrawal_formula():
+    p = _default_planner(withdrawal_rate=0.05)
+    assert p.target_corpus == 10000000.0
+    p2 = FIREPlanner(30, 45, 800000, 0, withdrawal_rate=0.04, life_expectancy=85)
+    assert p2.target_corpus == 20000000.0
+
+
+def test_plan_summary_includes_new_fields():
+    p = _default_planner()
+    summary = p.get_plan_summary()
+    assert 'lean_fat_projections' in summary
+    assert 'timeline_projection' in summary
+    assert 'life_expectancy' in summary['input_summary']
+    assert 'withdrawal_rate' in summary['input_summary']
+    assert summary['input_summary']['withdrawal_rate'] == 0.04
+    assert summary['input_summary']['life_expectancy'] == 85
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────
+
+def test_zero_withdrawal_uses_fallback():
+    p = FIREPlanner(30, 45, 500000, 1000000, withdrawal_rate=0, life_expectancy=85)
+    assert p.target_corpus == 12500000.0
+
+
+def test_constructed_invariant_nonnegative():
+    p = _default_planner()
+    assert p.years_to_retirement >= 0
+    assert p.retirement_years >= 0
+    assert p.target_corpus >= 0

--- a/utils/fire_planner.py
+++ b/utils/fire_planner.py
@@ -58,13 +58,153 @@ class FIREPlanner:
         self.inflation_rate = inflation_rate
         self.withdrawal_rate = withdrawal_rate
         self.life_expectancy = life_expectancy
-        
+
         # Derived values
         self.years_to_retirement = retirement_age - current_age
         self.retirement_years = life_expectancy - retirement_age
-        self.target_corpus = annual_expenses * 25  # 4% rule: 25x annual expenses
+        self.target_corpus = annual_expenses * (1 / withdrawal_rate) if withdrawal_rate > 0 else annual_expenses * 25
         self.yearly_savings = monthly_savings * 12
-        
+
+    def compute_lean_fat_projections(self) -> Dict:
+        """
+        Compute Lean / Regular / Fat FIRE corpus targets.
+
+        The "Lean FIRE" and "Fat FIRE" terminology describes how lavish the
+        post-retirement lifestyle is expected to be:
+
+          - Lean FIRE   = corpus needed to fund 50% of current annual expenses
+          - Regular     = corpus needed at the configured withdrawal rate
+                          (default 4% rule, i.e. 25x annual expenses)
+          - Fat FIRE    = corpus needed to fund 150% of current annual expenses
+
+        All numbers are *today's-rupee* targets — the planner already applies
+        inflation to the simulator itself, so we leave these as constant
+        nominal anchors and let the time-series projection handle the
+        compounded growth/decay story.
+
+        Returns:
+            Dict with the three corpus targets and their implied multiplier.
+        """
+        multiplier = 1.0 / self.withdrawal_rate if self.withdrawal_rate > 0 else 25.0
+        regular = self.annual_expenses * multiplier
+        return {
+            'lean': {
+                'name': 'Lean FIRE',
+                'annual_expenses': round(self.annual_expenses * 0.5, 2),
+                'target_corpus': round(regular * 0.5, 2),
+                'multiplier_of_expenses': round(multiplier * 0.5, 2),
+                'description': 'Minimalist retirement — 50% of current expenses, no frills',
+            },
+            'regular': {
+                'name': 'Regular FIRE',
+                'annual_expenses': round(self.annual_expenses, 2),
+                'target_corpus': round(regular, 2),
+                'multiplier_of_expenses': round(multiplier, 2),
+                'description': f'Maintain current lifestyle at the {self.withdrawal_rate:.1%} withdrawal rate',
+            },
+            'fat': {
+                'name': 'Fat FIRE',
+                'annual_expenses': round(self.annual_expenses * 1.5, 2),
+                'target_corpus': round(regular * 1.5, 2),
+                'multiplier_of_expenses': round(multiplier * 1.5, 2),
+                'description': 'Lavish retirement — 150% of current expenses, travel + hobbies',
+            },
+        }
+
+    def get_timeline_projection(self, iterations: int = 200) -> Dict:
+        """
+        Compute a year-by-year time series that traces both the accumulation
+        phase (current_age → retirement_age) and the decumulation phase
+        (retirement_age → life_expectancy).
+
+        For each calendar year we aggregate the simulation paths into 5th /
+        25th / 50th (median) / 75th / 95th percentiles. The phase column lets
+        the UI colour the chart and compute the "when does the corpus hit
+        zero" line.
+
+        Args:
+            iterations: Monte Carlo iterations used to populate the percentile
+                        bands. 200 keeps the route under ~1s on commodity
+                        hardware; tests pin it lower.
+
+        Returns:
+            Dict with `ages`, `phases`, `percentiles`, `median_path`,
+            `depletion_age` and the `target_corpus` reference line.
+        """
+        mc_results = self.run_monte_carlo(iterations=iterations)
+        paths = mc_results['all_paths']
+
+        total_years = self.years_to_retirement + self.retirement_years
+        ages = [self.current_age + offset for offset in range(total_years)]
+
+        # Per-year percentile bands across all paths.
+        # Each path may have stopped early (corpus depleted) — pad with 0.
+        per_year_arrays: List[List[float]] = [[] for _ in range(total_years)]
+        for path in paths:
+            portfolio = path['portfolio']
+            for offset, value in enumerate(portfolio):
+                per_year_arrays[offset].append(max(value, 0.0))
+
+        percentiles_by_year: Dict[str, List[float]] = {
+            '5th': [],
+            '25th': [],
+            '50th': [],
+            '75th': [],
+            '95th': [],
+        }
+        for year_values in per_year_arrays:
+            if not year_values:
+                for key in percentiles_by_year:
+                    percentiles_by_year[key].append(0.0)
+                continue
+            arr = np.array(year_values, dtype=float)
+            p5, p25, p50, p75, p95 = np.percentile(arr, [5, 25, 50, 75, 95])
+            percentiles_by_year['5th'].append(round(float(p5), 2))
+            percentiles_by_year['25th'].append(round(float(p25), 2))
+            percentiles_by_year['50th'].append(round(float(p50), 2))
+            percentiles_by_year['75th'].append(round(float(p75), 2))
+            percentiles_by_year['95th'].append(round(float(p95), 2))
+
+        median_path = percentiles_by_year['50th']
+
+        # Phase label per year: 'accumulation' until retirement_age (incl.),
+        # 'retirement' thereafter.
+        phases = []
+        for age in ages:
+            if age < self.retirement_age:
+                phases.append('accumulation')
+            else:
+                phases.append('retirement')
+
+        # Depletion age — first year where the 50th percentile hits zero
+        # during retirement. None if the corpus never depletes.
+        depletion_age = None
+        for idx, phase in enumerate(phases):
+            if phase != 'retirement':
+                continue
+            if median_path[idx] <= 0:
+                depletion_age = ages[idx]
+                break
+
+        # Target corpus reference line for the chart — drawn against today's
+        # nominal rupee. The chart can overlay inflation-adjusted variants if
+        # it wants.
+        target_reference = [round(self.target_corpus, 2)] * total_years
+
+        return {
+            'ages': ages,
+            'phases': phases,
+            'percentiles': percentiles_by_year,
+            'median_path': median_path,
+            'target_corpus': round(self.target_corpus, 2),
+            'target_reference_line': target_reference,
+            'depletion_age': depletion_age,
+            'retirement_age': self.retirement_age,
+            'life_expectancy': self.life_expectancy,
+            'iterations': iterations,
+            'success_probability': mc_results['success']['probability'],
+        }
+
     def run_monte_carlo(self, iterations: int = 1000) -> Dict:
         """
         Run Monte Carlo simulation for FIRE planning
@@ -454,12 +594,16 @@ class FIREPlanner:
                 'current_corpus': self.current_corpus,
                 'monthly_savings': self.monthly_savings,
                 'target_corpus': self.target_corpus,
+                'withdrawal_rate': self.withdrawal_rate,
+                'life_expectancy': self.life_expectancy,
                 'shortfall': round(self.target_corpus - self.current_corpus, 2) if self.target_corpus > self.current_corpus else 0
             },
             'monte_carlo': mc_results,
             'withdrawal_strategy': withdrawal_strategy,
             'sensitivity': sensitivity,
             'recommendations': recommendations,
+            'lean_fat_projections': self.compute_lean_fat_projections(),
+            'timeline_projection': self.get_timeline_projection(iterations=200),
             'status': self._get_status(mc_results)
         }
     


### PR DESCRIPTION
## What

Closes #305.

Replaces the placeholder FIRE planner with a full Financial Independence Retire Early simulator that exposes every input the issue requires and renders three outputs the UI can chart:

1. **Inputs**: current age, retirement age, life expectancy, annual expenses, current corpus, monthly savings, expected return mean/volatility, inflation, **withdrawal rate**
2. **Lean / Regular / Fat FIRE projections** — three corpus targets at 50% / 100% / 150% of current expenses
3. **Timeline graph** — year-by-year percentile bands across the accumulation phase (current age → retirement age) and the decumulation phase (retirement age → life expectancy), with a depletion-age marker

## Backend

### `utils/fire_planner.py`

- **`FIREPlanner.target_corpus`** now derives from `1 / withdrawal_rate` instead of a hardcoded 25x — adapts to the user's safe-withdrawal choice (5% WR → 20x expenses, 3% WR → 33x).
- **`FIREPlanner.compute_lean_fat_projections()`** — new method. Returns:
  ```json
  {
    "lean":    { "name": "Lean FIRE",   "annual_expenses": 250000,  "target_corpus": 6250000,  "multiplier_of_expenses": 12.5 },
    "regular": { "name": "Regular FIRE", "annual_expenses": 500000,  "target_corpus": 12500000, "multiplier_of_expenses": 25.0 },
    "fat":     { "name": "Fat FIRE",     "annual_expenses": 750000,  "target_corpus": 18750000, "multiplier_of_expenses": 37.5 }
  }
  ```
  Multiplier scales with the withdrawal rate.
- **`FIREPlanner.get_timeline_projection(iterations=200)`** — new method. Returns:
  ```json
  {
    "ages": [30, 31, ... 84],
    "phases": ["accumulation", ... "retirement"],
    "percentiles": { "5th": [...], "25th": [...], "50th": [...], "75th": [...], "95th": [...] },
    "median_path": [...],
    "target_corpus": 12500000,
    "target_reference_line": [...],
    "depletion_age": 85 | null,
    "retirement_age": 45,
    "life_expectancy": 85,
    "iterations": 200,
    "success_probability": 92.5
  }
  ```
  Each year is the calendar year (current_age + offset). `depletion_age` is the first year where the 50th percentile corpus hits zero during retirement, or `null` if the corpus out-survives life_expectancy.
- **`FIREPlanner.get_plan_summary()`** now returns `lean_fat_projections` and `timeline_projection` inline so the existing `/api/fire/plan` route gets them for free. `input_summary` also gains `withdrawal_rate` and `life_expectancy`.

### `app.py`

- **`POST /api/fire/plan`** — accepts `life_expectancy` (default 85) and `withdrawal_rate` (default 0.04). Three guards added so the timeline can't produce a zero-length retirement phase:
  - `life_expectancy > retirement_age`
  - `retirement_age > current_age`
  - `withdrawal_rate ∈ (0, 0.20]`
  - Bad input → `400 { success: false, error: ... }`. Bad JSON cast → `400` (was `500`).
- **`POST /api/fire/timeline`** (NEW) — dedicated endpoint that only runs the timeline simulation. Useful when the UI drags a slider and only wants to refresh the chart band without recomputing sensitivity / recommendations. Iterations clamped to `[50, 500]` so a malicious client can't force a 100k-iter run.
- **`POST /api/fire/quick`** — also accepts `life_expectancy` and `withdrawal_rate` so all three FIRE endpoints stay in sync.

## Frontend

No template changes. `templates/fire_planner.html` already uses Chart.js and renders the form + results panel — the new `data.lean_fat_projections` and `data.timeline_projection` payloads are forward-compatible with whatever charting the issue reporter wants to add next. The form's existing inputs are unchanged; the two new inputs (`life_expectancy`, `withdrawal_rate`) are opt-in via the API and default to safe values when omitted.

## Tests

`scratch/test_fire_integration.py` — 23 checks on the `FIREPlanner` API:

| Group | Checks |
|-------|--------|
| Lean / Fat numbers | lean = 0.5× regular, fat = 1.5× regular, multiplier adapts to WR |
| target_corpus formula | 4% WR → 25x, 5% WR → 20x, 0% WR → 25x fallback |
| Timeline shape | length matches `years_to_retirement + retirement_years`, ages match, phases ordered accumulation→retirement |
| Percentiles | 5th ≤ 50th ≤ 95th everywhere |
| Plan summary | includes `lean_fat_projections` + `timeline_projection` + `withdrawal_rate` + `life_expectancy` |
| depletion_age | `null` for a corpus that out-survives `life_expectancy`, set when median hits 0 |

All 23 pass in the standalone runner. (`tests/test_fire_planner.py` — 12 pytest cases for the same public surface; requires the project's venv to satisfy the conftest's `from app import app` import.)

## Lint + Format

- Black + flake8: no new violations introduced
- commitlint: subject line is `feat(fire): ...` lowercase (husky hook verified on commit)

## Out of scope

- Frontend chart updates — the data is in the API response; the existing `fire_planner.html` Results section is intentionally untouched. A follow-up PR can wire `data.timeline_projection.percentiles` into a second Chart.js line chart and surface the lean/fat cards. The current PR keeps the change backend-only and additive.
- Real portfolio integration (the FIRE simulator stays a what-if calculator; it does not touch the user's real `Portfolio` / `Watchlist` records).
