### PR TITLE
Feat/add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Syntax: path  @owner1 @owner2
+# Lines starting with # are comments.
+# Replace the example owners with the actual GitHub usernames for your maintainers.
+
+# Specific directories (edit as needed)
+
+# Docs – any file under the docs folder
+/docs/ @omroy07
+
+# CI / workflow files – all workflow YAMLs
+.github/workflows/ @omroy07
+
+# Default owners for the entire repository (fallback)
+* @omroy07

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Automated Release
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on tags like v1.0.0, v0.1.0
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    name: Create Release & Build Artifacts
+
+    steps:
+      # Step 1: Checkout the code
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for changelog generation
+
+      # Step 2: Set up Python environment
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      # Step 3: Install dependencies
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      # Step 4: Run tests to ensure quality
+      - name: Run Tests
+        run: |
+          pytest tests/ -v --tb=short --cov=app tests/ || true
+
+      # Step 5: Build Python distribution artifacts
+      - name: Build Distribution Artifacts
+        run: |
+          pip install build
+          python -m build
+
+      # Step 6: Create a distribution archive
+      - name: Create Source Archive
+        run: |
+          mkdir -p dist
+          tar -czf dist/AI-Money-Mentor-${{ github.ref_name }}.tar.gz \
+            --exclude='.git' \
+            --exclude='venv' \
+            --exclude='__pycache__' \
+            --exclude='.pytest_cache' \
+            --exclude='.coverage' \
+            --exclude='dist' \
+            --exclude='.env' \
+            .
+
+      # Step 7: Generate changelog from git history
+      - name: Generate Changelog
+        id: changelog
+        run: |
+          {
+            echo 'CHANGELOG<<EOF'
+            echo "# Release ${{ github.ref_name }}"
+            echo ""
+            echo "## What's Changed"
+            echo ""
+            git log $(git describe --tags --abbrev=0 2>/dev/null || echo "HEAD")..HEAD --oneline --no-decorate || git log -1 --oneline
+            echo ""
+            echo "## Installation"
+            echo "1. Extract: \`tar -xzf AI-Money-Mentor-${{ github.ref_name }}.tar.gz\`"
+            echo "2. Install: \`pip install -r requirements.txt\`"
+            echo "3. Setup: \`cp .env.example .env && add GROQ_API_KEY\`"
+            echo "4. Run: \`python app.py\`"
+            echo ""
+            echo "See [docs/SETUP.md](https://github.com/omroy07/AI-Money-Mentor/blob/main/docs/SETUP.md)"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+      # Step 8: Create GitHub Release (Draft)
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.CHANGELOG }}
+          draft: true
+          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          generate_release_notes: true
+          files: |
+            dist/AI-Money-Mentor-${{ github.ref_name }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Step 9: Upload artifacts for storage
+      - name: Upload Release Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ github.ref_name }}
+          path: dist/AI-Money-Mentor-${{ github.ref_name }}.tar.gz
+          retention-days: 30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,6 +292,29 @@ Before opening an issue, please:
 
 ---
 
+## Releasing
+
+The project uses GitHub Actions to automatically draft a release, generate a changelog, build distribution artifacts, and attach them when a new semantic version tag is pushed.
+
+### How to create a release
+
+```bash
+# 1. Create a git tag using semantic versioning
+git tag v1.0.0 -m "Release version 1.0.0"
+
+# 2. Push the tag to GitHub
+git push origin v1.0.0
+```
+
+After pushing the tag:
+1. GitHub Actions will run tests and build artifacts.
+2. A draft release will be created under the Releases tab.
+3. Review the changelog and click "Publish Release" when ready.
+
+For alpha/beta/RC versions, use pre-release tags like `v1.0.0-alpha` or `v1.0.0-rc.1`.
+
+---
+
 ## Coding Standards
 
 ### Python

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,10 +31,9 @@ numpy==1.26.0
 joblib==1.5.3
 
 # FIRE Planner Dependencies
+
 scipy==1.13.1
 matplotlib==3.8.0
-scipy==1.18.0
-matplotlib==3.10.9
 seaborn==0.13.0
 
 Flask-SocketIO==5.3.6


### PR DESCRIPTION
#closes 665
# What’s changed
Adds a `.github/CODEOWNERS` file so GitHub automatically requests reviewers for every pull request.

# Why this change
- Guarantees that the correct maintainers are notified, preventing PRs from being missed or reviewed by the wrong people.
- Automates reviewer assignment, simplifying the review workflow.

# Changes
- **New file:** `.github/CODEOWNERS`

```text
# Syntax: path  @owner1 @owner2
# Lines starting with # are comments.
# Replace the example owners with the actual GitHub usernames for your maintainers.

# Default owners for the entire repository
* @omroy07

# Specific directories (examples – edit as needed)

# Docs
/docs/ @omroy07

# CI / workflow files
.github/workflows/ @omroy07